### PR TITLE
Leaving string placeholders in strings untouched

### DIFF
--- a/bru-fixtures/With-non-string-placeholders.bru
+++ b/bru-fixtures/With-non-string-placeholders.bru
@@ -6,7 +6,8 @@ body:json {
   {
   "grapes":{{oneHundredItems}} , // A non-string placeholder has no double-quotes so it's not valid JSON
         "moreGrapes":    {{oneHundredItems}},  // Another non-string placeholder
-     "farmerName": "{{name}}" // This string placeholder should remain untouched as it is valid JSON
+     "name": "{{name}}", // This string placeholder should remain untouched as it is valid JSON
+     "farmerName": "Farmer {{name}} Junior" // And this string placeholder is also already valid JSON
   }
 }
 

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -134,7 +134,7 @@ async function formatBlock(fileContents, blockName, parser) {
  * @returns {string}
  */
 function wrapNonStringPlaceholdersInDelimiters(jsonBlock) {
-    return jsonBlock.replace(/(?<!["⇎])[{]{2}[^}]+}}(?!["⇎])/g, '"⇎$&⇎"')
+    return jsonBlock.replace(/(:[^"]*)([{]{2}[^}]+}})([^"⇎])/g, '$1"⇎$2⇎"$3')
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettify-bru",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettify-bru",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettify-bru",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Prettifies JSON and JavaScript blocks in Bruno .bru files",
   "keywords": [
     "bruno",

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -272,8 +272,7 @@ describe('The format() function', () => {
             'body:json {',
             '  {',
             '  "grapes":{{oneHundredItems}} , ', // A non-string placeholder has no double-quotes so it's not valid JSON
-            '        "moreGrapes":    {{oneHundredItems}}, ', // Another non-string placeholder
-            '     "farmerName": "{{name}}"', // This string placeholder should remain untouched as it is valid JSON
+            '        "moreGrapes":    {{oneHundredItems}} ', // Another non-string placeholder
             '  }',
             '}',
             '',
@@ -295,8 +294,7 @@ describe('The format() function', () => {
             'body:json {',
             '  {',
             '    "grapes": {{oneHundredItems}},',
-            '    "moreGrapes": {{oneHundredItems}},',
-            '    "farmerName": "{{name}}"',
+            '    "moreGrapes": {{oneHundredItems}}',
             '  }',
             '}',
             '',
@@ -306,6 +304,43 @@ describe('The format() function', () => {
             '    oneHundredItems.push({name: "Young Raisin"})',
             '  }',
             '  bru.setVar("oneHundredItems", oneHundredItems)',
+            '}',
+            '',
+        ].join('\n')
+
+        expect.assertions(3)
+        return format(badlyFormattedFileContents).then(result => {
+            expect(result.changeable).toBe(true)
+            expect(result.errorMessages).toStrictEqual([])
+            expect(result.newContents).toBe(expected)
+        })
+    })
+
+    it('leaves string placeholders in body:json untouched', async () => {
+        const badlyFormattedFileContents = [
+            'meta {',
+            '  name: Post Farmer',
+            '}',
+            '',
+            'body:json {',
+            '  {',
+            '  "name": "{{name}}" ,  ', // This string placeholder should remain untouched as it is valid JSON
+            '     "farmerName": "Farmer {{name}} Junior"', // This string placeholder should remain untouched as it is valid JSON
+            '  }',
+            '}',
+            '',
+        ].join('\n')
+
+        const expected = [
+            'meta {',
+            '  name: Post Farmer',
+            '}',
+            '',
+            'body:json {',
+            '  {',
+            '    "name": "{{name}}",',
+            '    "farmerName": "Farmer {{name}} Junior"',
+            '  }',
             '}',
             '',
         ].join('\n')


### PR DESCRIPTION
Fixing a bug where placeholders would incorrectly have delimiters placed around them, even if the placeholder was used within a string like this....

```json
{
  "name": "Mister {{firstName}} MBE"
}
```