### PR TITLE
Patch 1.8.1 fixes bug: Console colour was not resetting

### DIFF
--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -83,7 +83,7 @@ export async function main(console, cwd, path, write, only = null) {
     if (requireNothing > 0) {
         let requireNothingMessage = requireNothing === files.length ? '\x1b[32m' : '\x1b[2m'
         requireNothingMessage += `${requireNothing} file` + (requireNothing > 1 ? 's' : '')
-        console.log(`  ${requireNothingMessage} did not require any changes`)
+        console.log(`  ${requireNothingMessage} did not require any changes\x1b[0m`)
     }
 
     return erroredFiles.length > 0 || changeableFiles.length > 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettify-bru",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettify-bru",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "jsonc-parser": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettify-bru",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Prettifies JSON and JavaScript blocks in Bruno .bru files",
   "keywords": [
     "bruno",


### PR DESCRIPTION
After setting the final report line to be grey or green, line 86 in main.mjs was missing the colour reset command. Silly mistake, easy fix. 