### PR TITLE
Format text with colors only when supported

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,4 +1,5 @@
 import {readIfExists} from './files.mjs'
+import {styleText} from 'node:util'
 
 const configFilename = '.prettifybrurc'
 
@@ -44,17 +45,20 @@ export function parseFile(console, fileContents) {
         fileConfig = JSON.parse(fileContents)
     } catch (e) {
         console.error(
-            `\x1b[31mError parsing JSON in ${configFilename} config file:\n${e.message}\x1b[0m\n`
+            styleText('red', `Error parsing JSON in ${configFilename} config file:\n${e.message}`) +
+                '\n'
         )
         return {}
     }
 
     if (fileConfig instanceof Array || typeof fileConfig !== 'object') {
-        console.error(`\x1b[31m${configFilename} is not valid, the JSON is not an Object\x1b[0m\n`)
+        console.error(
+            styleText('red', `${configFilename} is not valid, the JSON is not an Object`) + '\n'
+        )
         return {}
     }
 
-    console.log(`🔧 \x1b[2mUsing config file ${configFilename}\x1b[0m`)
+    console.log(`🔧 ${styleText('dim', `Using config file ${configFilename}`)}`)
 
     let config = {}
 
@@ -73,11 +77,11 @@ export function parseFile(console, fileContents) {
                 config[key] = fileConfig[key]
             } else {
                 console.warn(
-                    `⚠️  \x1b[33m"${key}" is not correct type, it should be ${validType}\x1b[0m`
+                    `⚠️  ${styleText('yellow', `"${key}" is not correct type, it should be ${validType}`)}`
                 )
             }
         } else {
-            console.warn(`⚠️  \x1b[33mIgnoring unsupported property "${key}"\x1b[0m`)
+            console.warn(`⚠️  ${styleText('yellow', `Ignoring unsupported property "${key}"`)}`)
         }
     })
 

--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -1,6 +1,7 @@
 import {findFiles, readFile, writeFile} from './files.mjs'
 import {format} from './format.mjs'
 import {loadConfigFile} from './config.mjs'
+import {styleText} from 'node:util'
 
 /**
  * Finds all .bru files and formats contents
@@ -47,13 +48,13 @@ export async function main(console, cwd, path, write, only = null) {
     const changeableSuffix = write ? 'reformatted' : 'require reformatting'
     let changeableReport = null
     if (changeableFiles.length) {
-        const changeableCol = write ? '\x1b[32m' : '\x1b[33m'
+        const changeableColor = write ? 'green' : 'yellow'
         const emoji = write ? '✏️' : '⚠️'
         const changeableFilesDesc = fileDesc(changeableFiles)
-        changeableReport = `${changeableCol}${changeableFilesDesc} ${changeableSuffix}`
-        console.log(`\x1b[4m${changeableReport}:\x1b[0m\n`)
+        changeableReport = styleText(changeableColor, `${changeableFilesDesc} ${changeableSuffix}`)
+        console.log(styleText('underline', `${changeableReport}:`) + '\n')
         changeableFiles.forEach(r =>
-            console.log(`${emoji}  ${changeableCol}${r.displayFilePath}\x1b[0m`)
+            console.log(`${emoji}  ${styleText(changeableColor, r.displayFilePath)}`)
         )
         console.log(' ')
     }
@@ -61,12 +62,12 @@ export async function main(console, cwd, path, write, only = null) {
     let erroredReport = null
     if (erroredFiles.length) {
         const erroredFilesDesc = fileDesc(erroredFiles)
-        erroredReport = `\x1b[31m${erroredFilesDesc} causing errors`
-        console.warn(`\x1b[4m${erroredReport}:\x1b[0m\n`)
+        erroredReport = styleText('red', `${erroredFilesDesc} causing errors`)
+        console.warn(styleText('underline', `${erroredReport}:`) + '\n')
         erroredFiles.forEach((r, i) => {
             console.warn(`${i + 1}) ${r.displayFilePath}\n`)
             r.outcome.errorMessages.forEach(err => {
-                console.warn(`❌ \x1b[31m${err}\x1b[0m\n`)
+                console.warn(`❌ ${styleText('red', err)}\n`)
             })
         })
     }
@@ -75,15 +76,17 @@ export async function main(console, cwd, path, write, only = null) {
     const filesDesc = fileDesc(files)
     console.log(`Inspected ${filesDesc}:`)
     if (changeableReport) {
-        console.log(`  ${changeableReport}\x1b[0m`)
+        console.log(`  ${changeableReport}`)
     }
     if (erroredReport) {
-        console.log(`  ${erroredReport}\x1b[0m`)
+        console.log(`  ${erroredReport}`)
     }
     if (requireNothing > 0) {
-        let requireNothingMessage = requireNothing === files.length ? '\x1b[32m' : '\x1b[2m'
-        requireNothingMessage += `${requireNothing} file` + (requireNothing > 1 ? 's' : '')
-        console.log(`  ${requireNothingMessage} did not require any changes\x1b[0m`)
+        const requireNothingColor = requireNothing === files.length ? 'green' : 'dim'
+        const requireNothingMessage = `${requireNothing} file` + (requireNothing > 1 ? 's' : '')
+        console.log(
+            `  ${styleText(requireNothingColor, `${requireNothingMessage} did not require any changes`)}`
+        )
     }
 
     return erroredFiles.length > 0 || changeableFiles.length > 0

--- a/test/config/config_parse_file.test.js
+++ b/test/config/config_parse_file.test.js
@@ -1,4 +1,5 @@
 import {jest, it, expect, describe} from '@jest/globals'
+import {styleText} from 'node:util'
 import {parseFile} from '../../lib/config.mjs'
 
 describe('parseFile() function in config module', () => {
@@ -7,7 +8,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{}')
 
         expect(mockConsole.log).toHaveBeenCalledWith(
-            '🔧 \x1b[2mUsing config file .prettifybrurc\x1b[0m'
+            `🔧 ${styleText('dim', 'Using config file .prettifybrurc')}`
         )
         expect(config).toEqual({})
     })
@@ -17,7 +18,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, fileContents)
 
         expect(mockConsole.error).toHaveBeenCalledWith(
-            '\x1b[31m.prettifybrurc is not valid, the JSON is not an Object\x1b[0m\n'
+            styleText('red', '.prettifybrurc is not valid, the JSON is not an Object') + '\n'
         )
         expect(config).toEqual({})
     })
@@ -35,7 +36,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"agnosticFilePaths": ["yes"]}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            '⚠️  \x1b[33m"agnosticFilePaths" is not correct type, it should be a boolean\x1b[0m'
+            `⚠️  ${styleText('yellow', '"agnosticFilePaths" is not correct type, it should be a boolean')}`
         )
         expect(config).toEqual({})
     })
@@ -46,7 +47,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"shortenGetters": "yes"}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            '⚠️  \x1b[33m"shortenGetters" is not correct type, it should be a boolean\x1b[0m'
+            `⚠️  ${styleText('yellow', '"shortenGetters" is not correct type, it should be a boolean')}`
         )
         expect(config).toEqual({})
     })
@@ -57,7 +58,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"prettier": ["tabWidth", 2]}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            '⚠️  \x1b[33m"prettier" is not correct type, it should be an object\x1b[0m'
+            `⚠️  ${styleText('yellow', '"prettier" is not correct type, it should be an object')}`
         )
         expect(config).toEqual({})
     })
@@ -67,7 +68,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"fish": "horse"}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            '⚠️  \x1b[33mIgnoring unsupported property "fish"\x1b[0m'
+            `⚠️  ${styleText('yellow', 'Ignoring unsupported property "fish"')}`
         )
         expect(config).toEqual({})
     })


### PR DESCRIPTION
You have hardcoded shell colors to be printed out. This is fine until you are using the tool in environment, which doesn't support colors. This PR fixes that by using native Node function, which handles all of that.

For testing, you can run this command `node cli.js > file.out` and you will see that file will look like this

```
[4m[33m11 files require reformatting:[0m

⚠️  [33mbru-fixtures/array-items-on-1-line.bru[0m
⚠️  [33mbru-fixtures/backslash-folder-separators.bru[0m
⚠️  [33mbru-fixtures/empty-tests-block.bru[0m
⚠️  [33mbru-fixtures/excess-newlines-between-blocks.bru[0m
⚠️  [33mbru-fixtures/excess-newlines-in-json-body.bru[0m
⚠️  [33mbru-fixtures/fix-graphql-body.bru[0m
⚠️  [33mbru-fixtures/fix-graphql-vars.bru[0m
⚠️  [33mbru-fixtures/getters-used-on-res-object.bru[0m
⚠️  [33mbru-fixtures/invalid-json-body.bru[0m
⚠️  [33mbru-fixtures/non-string-placeholders.bru[0m
⚠️  [33mbru-fixtures/single-quotes-in-javascript.bru[0m
 
Inspected 13 files:
  [33m11 files require reformatting[0m
  [2m2 files did not require any changes[0m

```

But after my fix it will be 

```
11 files require reformatting:

⚠️  bru-fixtures/array-items-on-1-line.bru
⚠️  bru-fixtures/backslash-folder-separators.bru
⚠️  bru-fixtures/empty-tests-block.bru
⚠️  bru-fixtures/excess-newlines-between-blocks.bru
⚠️  bru-fixtures/excess-newlines-in-json-body.bru
⚠️  bru-fixtures/fix-graphql-body.bru
⚠️  bru-fixtures/fix-graphql-vars.bru
⚠️  bru-fixtures/getters-used-on-res-object.bru
⚠️  bru-fixtures/invalid-json-body.bru
⚠️  bru-fixtures/non-string-placeholders.bru
⚠️  bru-fixtures/single-quotes-in-javascript.bru
 
Inspected 13 files:
  11 files require reformatting
  2 files did not require any changes

```