### PR TITLE
Support placeholders in JSON keys, arrays and GraphQL vars

### DIFF
--- a/bru-fixtures/array-items-on-1-line.bru
+++ b/bru-fixtures/array-items-on-1-line.bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "bitters": ["Angostura", "{{fish}}"],
+    "bitters": ["Angostura", "{{fish}}", {{food}}],
     "ice": true
   }
 }

--- a/bru-fixtures/fix-graphql-body.bru
+++ b/bru-fixtures/fix-graphql-body.bru
@@ -13,13 +13,13 @@ post {
 body:graphql {
   mutation createCocktail(
       $name: String!
-      $displayName: String
       $description: String
   ) {
     createCocktail(
       input: {
           name: $name,
-            displayName: $displayName,
+            type: "{{some_placeholder_inside_quotes}}",
+            displayName: {{some_placeholder_without_quotes}},
         description: $description}
     ) {
       id

--- a/bru-fixtures/fix-graphql-vars.bru
+++ b/bru-fixtures/fix-graphql-vars.bru
@@ -29,13 +29,13 @@ body:graphql {
       __typename
     }
   }
-  
+
 }
 
 body:graphql:vars {
   {
     "name" : "{{customerName}}",
-      "displayName": "{{customerDisplayName}}",
+      {{placeholder_as_json_key}}: "{{customerDisplayName}}",
     "description": "{{customerDescription}}"
   }
 }

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -25,6 +25,9 @@ const formattableBlocks = [
     'tests',
 ]
 
+const maskPattern = /("(?:\\.|[^"\\])*")|(\{\{.*?\}\})/g
+const unmaskPattern = /"__⇎⇎START__(\{\{.*?\}\})__END⇎⇎__"/g
+
 /**
  * @typedef {Object} FileOutcome
  * @property {string} newContents
@@ -140,8 +143,12 @@ async function formatBlock(fileContents, blockName, config) {
             if (blockName === 'body:graphql') {
                 opts.parser = 'graphql'
                 opts.bracketSpacing = true
+                unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
             }
             reformatted = await prettier.format(unindented, opts)
+            if (blockName === 'body:graphql') {
+                reformatted = unwrapDelimitedPlaceholders(reformatted)
+            }
         } catch (e) {
             outcome.errorMessage = `Prettier could not format ${blockName} because...\n${e.message}`
             return outcome
@@ -189,23 +196,33 @@ function shortenGetters(blockContents) {
 }
 
 /**
- * Turns Bruno variable placeholders into strings with special delimiters, effectively making it valid JSON
+ * Turns Bruno variable placeholders into strings with special delimiters, effectively making it valid JSON,
+ * and for standard cases also valid GraphQL.
  *
- * @param {string} jsonBlock
+ * @param {string} block
  * @returns {string}
  */
-function wrapNonStringPlaceholdersInDelimiters(jsonBlock) {
-    return jsonBlock.replace(/(:[^"]*)([{]{2}[^}]+}})([^"⇎])/g, '$1"⇎$2⇎"$3')
+function wrapNonStringPlaceholdersInDelimiters(block) {
+    return block.replace(maskPattern, (match, group1, group2) => {
+        // If group1 exists, we found a standard JSON string. Return it untouched.
+        if (group1) {
+            return group1
+        }
+
+        // If group2 exists, we found a placeholder outside a string.
+        // Wrap it in a unique dummy string.
+        return `"__⇎⇎START__${group2}__END⇎⇎__"`
+    })
 }
 
 /**
  * Reverts delimited Bruno variable placeholders back to their original form within a JSON block.
  *
- * @param {string} jsonBlock
+ * @param {string} block
  * @returns {string}
  */
-function unwrapDelimitedPlaceholders(jsonBlock) {
-    return jsonBlock.replace(/"⇎({{[^}]+}})⇎"/g, '$1')
+function unwrapDelimitedPlaceholders(block) {
+    return block.replace(unmaskPattern, '$1')
 }
 
 /**


### PR DESCRIPTION
Fixes #20

I have learned some really useful, how to think about regexes actually.

I was always trying to build robust regex, that would match `{{xx}}` but if it isn't inside string. But the regex that Gemini suggested `/("(?:\\.|[^"\\])*")|(\{\{.*?\}\})/g` works in a way, that it matches strings, but also matches placeholders.

The trick here is, that matching string has higher priority - is first in OR (`|`) group. So if string is matched, regex engine goes to the end and continues there. So second part (handling real placeholder) will never match anything inside string - the group that was already matched.

You can try it out here: https://regex101.com/r/8qI02l/1