### PR TITLE
Implementing JavaScript linting using ESLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.0
+
+New feature of JavaScript linting using ESLint package and major change to issue report so it describes what is wrong with each file where possible.
+
 ## 1.10.0
 
 Introduces new `jsonFormatter` option to allow users to configure which package is used to format JSON blocks. See [JSON Formatter](README.md#json-formatter).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 A CLI tool to [prettify and format Bruno `.bru` files](https://www.npmjs.com/package/prettify-bru).
 
-Removes junk and makes code shorter and more transferable between systems.
+Removes junk, lints JavaScript for errors and makes code shorter and more transferable between systems.
 Imposes a standard format on all blocks of JSON and JavaScript code across multiple [Bruno](https://www.usebruno.com/) `.bru` files in your project.
 
-`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally using [Prettier](https://prettier.io/) (with the `jsonc` parser) when the `jsonFormatter` option is set to "prettier".
+JSON blocks (`body:json` and `body:graphql:vars`) are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally using [Prettier](https://prettier.io/) (with the `jsonc` parser) when the `jsonFormatter` option is set to "prettier".
 
-`script:pre-request`, `script:post-response` and `tests` blocks are formatted using [Prettier](https://prettier.io/) with [Babel](https://babeljs.io/docs/babel-parser) parser.
+JavaScript blocks (`script:pre-request`, `script:post-response` and `tests`) are linted using [ESLint](https://eslint.org/) and then formatted using [Prettier](https://prettier.io/).
 
 `body:graphql` blocks are formatted using [Prettier](https://prettier.io/) with GraphQL parser.
 
@@ -31,6 +31,7 @@ Imposes a standard format on all blocks of JSON and JavaScript code across multi
   - [Shorten Getters](#shorten-getters)
   - [JSON Formatter](#json-formatter)
   - [Prettier](#prettier)
+  - [ESLint](#eslint)
 - [Automatically checking PRs](#automatically-checking-prs)
 <!-- TOC -->
 
@@ -60,7 +61,7 @@ Thanks, Martin
 
 ## Installation
 
-Requires Node.js 20+
+Requires Node.js 20.19 or higher
 
 To install in your project, run:
 
@@ -216,7 +217,43 @@ For example, to increase the line length limit from the default 80 up to 120 cha
 }
 ```
 
-*Note: Config file is supported from version [1.6.0](CHANGELOG.md#160) and above.*
+### ESLint
+
+Property: `esLintRules` {"recommended"|Object|false} (Default: "recommended")
+
+Set it to the string "recommended" to use Martin's recommended ruleset:
+
+```json
+{
+    "esLintRules": "recommended"
+}
+```
+
+The recommended ruleset is currently `no-console`, `no-redeclare`, `no-sequences`, `no-unused-vars` and `no-var` all set as "error" and `prefer-arrow-callback` and `prefer-const` set as "warn". This ruleset may change in future versions as I experiment with them in daily Bruno use.
+
+Completely turn off linting of your JavaScript blocks by setting `esLintRules` to `false`:
+
+```json
+{
+    "esLintRules": false
+}
+```
+
+Define your own set of rules and severity level by setting it to an object of key-value pairs with the rule name as the key and either "error", "warn", or "off" as the value. [Full list of ESLint rules](https://eslint.org/docs/latest/rules/).
+
+The following example enables 2 rules at different severity levels. The `no-console` rule only causes a warning so even if some code is detected which breaks the rule, it will not prevent the script from returning an exit code of 0 (Success). The `no-unused-vars` rule is set to "error" meaning any violations will result in exit code 1 (Error). Finally, the `prefer-const` rule is off:
+
+```json
+{
+    "esLintRules": {
+        "no-console": "warn",
+        "no-unused-vars": "error",
+        "prefer-const": "off"
+    }
+}
+```
+
+_Note: Config file is supported from version [1.6.0](CHANGELOG.md#160) and above._
 
 ## Automatically checking PRs
 

--- a/bru-fixtures/unused-const-in-javascript.bru
+++ b/bru-fixtures/unused-const-in-javascript.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Unused const in JavaScript
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{host}}/cucumber
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "green": true
+  }
+}
+
+tests {
+  test("Body should be an array", function () {
+    expect(res.body).to.be.an("array")
+  })
+}
+
+script:pre-request {
+  var body = null
+  var body = req.body
+  console.log(body)
+}
+
+script:post-response {
+  const body = res.body;
+  for (let i = 0; i < 100; i++) {
+    bru.setVar(`var${i}`, i)
+  }
+}
+
+docs {
+  We expect ESLint to pick-up the use of var, the redeclare, the console output and the unused const as errors
+}

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -9,6 +9,7 @@ const configFilename = '.prettifybrurc'
  * @property {boolean} shortenGetters
  * @property {'jsonc-parser'|'prettier'} jsonFormatter
  * @property {Object} prettier Prettier options
+ * @property {('recommended'|Object|false)} esLintRules ESLint rules configuration
  */
 
 /** @type {PrettifyBruConfig} */
@@ -17,6 +18,7 @@ export const defaultConfig = {
     shortenGetters: true,
     jsonFormatter: 'jsonc-parser',
     prettier: {},
+    esLintRules: 'recommended',
 }
 
 /**
@@ -68,18 +70,22 @@ export function parseFile(console, fileContents) {
         shortenGetters: 'a boolean',
         jsonFormatter: 'jsonc-parser or prettier',
         prettier: 'an object',
+        esLintRules: ['the string "recommended"', 'an object', 'false'],
     }
     Object.keys(fileConfig).forEach(key => {
         if (Object.hasOwn(supportedProperties, key)) {
             const value = fileConfig[key]
-            const validType = supportedProperties[key]
-            const validates = validators[validType]
+            let validTypes = supportedProperties[key]
 
-            if (validates(value)) {
+            if (!Array.isArray(validTypes)) {
+                validTypes = [validTypes]
+            }
+
+            if (validate(validTypes, value)) {
                 config[key] = fileConfig[key]
             } else {
                 console.warn(
-                    `⚠️  ${styleText('yellow', `"${key}" is not correct type, it should be ${validType}`)}`
+                    `⚠️  ${styleText('yellow', `"${key}" is not correct type, it should be ${validTypes.join(' or ')}`)}`
                 )
             }
         } else {
@@ -87,9 +93,25 @@ export function parseFile(console, fileContents) {
         }
     })
 
+    if (!Object.hasOwn(fileConfig, 'esLintRules')) {
+        console.log(
+            `   ${styleText('dim', `"esLintRules" is not set. Defaulting to recommended ruleset.`)}`
+        )
+    }
+
     console.log(' ')
 
     return config
+}
+
+function validate(validTypes, value) {
+    for (const validType of validTypes) {
+        const validator = validators[validType]
+        if (validator(value) === true) {
+            return true
+        }
+    }
+    return false
 }
 
 const validators = {
@@ -100,4 +122,6 @@ const validators = {
         return typeof value === 'boolean'
     },
     'jsonc-parser or prettier': value => value === 'jsonc-parser' || value === 'prettier',
+    false: value => value === false,
+    'the string "recommended"': value => value === 'recommended',
 }

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -1,5 +1,6 @@
 import prettier from 'prettier'
 import {defaultConfig} from './config.mjs'
+import {lint} from './lint.mjs'
 import {onlyParamOptions, validateOnlyParam} from './onlyParam.mjs'
 import {format as jsoncFormat, applyEdits} from 'jsonc-parser'
 
@@ -29,11 +30,25 @@ const maskPattern = /("(?:\\.|[^"\\])*")|(\{\{.*?\}\})/g
 const unmaskPattern = /"__⇎⇎START__(\{\{.*?\}\})__END⇎⇎__"/g
 
 /**
- * @typedef {Object} FileOutcome
+ * @typedef {Object} FileOutcome Represents the result of processing a file
  * @property {string} newContents
  * @property {number} blocksSearchedFor
- * @property {boolean} changeable
- * @property {string[]} errorMessages
+ * @property {boolean} changeable Indicates if there are any changes that can be made
+ * @property {BlockReport[]} blockReports
+ */
+
+/**
+ * @typedef {Object} BlockReport Represents the result of processing a block
+ * @property {?string} blockName If null, it relates to the file structure in generate, not a specific block
+ * @property {Issue[]} issues
+ */
+
+/**
+ * @typedef {Object} Issue Represents a single problem
+ * @property {boolean} [fatal]
+ * @property {boolean} fixable
+ * @property {number} severity 1 = Warning, 2 = Error
+ * @property {string} message Description of the problem
  */
 
 /**
@@ -43,9 +58,17 @@ const unmaskPattern = /"__⇎⇎START__(\{\{.*?\}\})__END⇎⇎__"/g
  * @param {string} originalContents The file contents as loaded from file system
  * @param {?string} only Limit to only the block type with a name containing value
  * @param {Object} configOverrides Could be whole PrettifyBruConfig or partial
+ * @param {?import('eslint').ESLint} esLintEngine
+ * @param {boolean} fix Whether to apply the fixes for fixable issues
  * @returns {Promise<FileOutcome>}
  */
-export async function format(originalContents, only = null, configOverrides = {}) {
+export async function format(
+    originalContents,
+    only = null,
+    configOverrides = {},
+    esLintEngine = null,
+    fix = false
+) {
     validateOnlyParam(only)
 
     /** @type {import('./config.mjs').PrettifyBruConfig} */
@@ -59,21 +82,33 @@ export async function format(originalContents, only = null, configOverrides = {}
         ),
     }
 
+    /** @type FileOutcome */
     let fileOutcome = {
         newContents: originalContents.replace(/\r\n/g, '\n'),
         blocksSearchedFor: 0,
         changeable: false,
-        errorMessages: [],
+        blockReports: [],
     }
 
     for (const blockName of formattableBlocks) {
         if (only !== null && !blockName.match(onlyParamOptions[only])) continue
 
-        const blockOutcome = await formatBlock(fileOutcome.newContents, blockName, config)
+        const blockOutcome = await formatBlock(
+            fileOutcome.newContents,
+            blockName,
+            config,
+            esLintEngine,
+            fix
+        )
         fileOutcome.blocksSearchedFor++
-        if (blockOutcome.errorMessage !== null) {
-            fileOutcome.errorMessages.push(blockOutcome.errorMessage)
-        } else if (blockOutcome.changeable) {
+
+        if (blockOutcome.issues.length) {
+            fileOutcome.blockReports.push({
+                blockName: blockName,
+                issues: [...blockOutcome.issues],
+            })
+        }
+        if (blockOutcome.changeable) {
             fileOutcome.changeable = true
             fileOutcome.newContents = blockOutcome.fileContents
         }
@@ -85,14 +120,20 @@ export async function format(originalContents, only = null, configOverrides = {}
         if (emptyBlockOutcome.changeable) {
             fileOutcome.changeable = true
             fileOutcome.newContents = emptyBlockOutcome.fileContents
+            fileOutcome.blockReports.push({
+                blockName: blockName,
+                issues: [{fixable: true, message: 'No contents', severity: 2}],
+            })
         }
     })
 
     if (only === null && config.agnosticFilePaths) {
         const fileBodyBlockOutcome = formatFilePaths(fileOutcome.newContents)
-        if (fileBodyBlockOutcome.errorMessage !== null) {
-            fileOutcome.errorMessages.push(fileBodyBlockOutcome.errorMessage)
-        } else if (fileBodyBlockOutcome.changeable) {
+        if (fileBodyBlockOutcome.messages.length) {
+            fileOutcome.blockReports.push({
+                blockName: 'body:file',
+                issues: [...fileBodyBlockOutcome.messages],
+            })
             fileOutcome.changeable = true
             fileOutcome.newContents = fileBodyBlockOutcome.fileContents
         }
@@ -101,6 +142,10 @@ export async function format(originalContents, only = null, configOverrides = {}
     const overallOutcome = formatOverallStructure(fileOutcome.newContents)
     if (overallOutcome.changeable) {
         fileOutcome.changeable = true
+        fileOutcome.blockReports.push({
+            blockName: null,
+            issues: [{fixable: true, message: 'Excess lines between blocks', severity: 2}],
+        })
         fileOutcome.newContents = overallOutcome.fileContents
     }
 
@@ -109,14 +154,16 @@ export async function format(originalContents, only = null, configOverrides = {}
 
 /**
  * @param {string} fileContents
- * @param {string} blockName
+ * @param {string} blockName The block to search for within the file contents
  * @param {import('./config.mjs').PrettifyBruConfig} config
- * @returns {Promise<{fileContents: string, changeable: boolean, errorMessage: ?string}>}
+ * @param {?import('eslint').ESLint} esLintEngine
+ * @param {boolean} fix Whether to apply the fixes for fixable issues
+ * @returns {Promise<{fileContents: string, blockName: string, changeable: boolean, issues: Issue[]}>}
  */
-async function formatBlock(fileContents, blockName, config) {
-    let outcome = {fileContents, changeable: false, errorMessage: null}
+async function formatBlock(fileContents, blockName, config, esLintEngine, fix) {
+    let outcome = {fileContents, blockName, changeable: false, issues: []}
 
-    const blockBodyRegex = new RegExp('\n' + blockName + ' [{]\\n(.+?)\\n}\\n', 's')
+    const blockBodyRegex = new RegExp('\n' + blockName + ' [{]\\n(  .+?)\\n}\\n', 's')
     const match = fileContents.match(blockBodyRegex)
     if (match === null) {
         return outcome
@@ -126,16 +173,30 @@ async function formatBlock(fileContents, blockName, config) {
     // Remove 2-spaces of indentation, added due to being inside a Bru lang block
     let unindented = rawBody.replace(/^  /gm, '')
 
+    const blockType = calculateBlockType(blockName)
+
+    if (esLintEngine !== null && blockType === 'JavaScript') {
+        const lintOutcome = await lint(unindented, esLintEngine, fix)
+        if (lintOutcome.messages.length > 0) {
+            outcome.issues.push(...lintOutcome.messages)
+            outcome.changeable = lintOutcome.messages.some(message => message.fixable)
+        }
+        if (fix) {
+            unindented = lintOutcome.code
+        }
+    }
+
     if (config.shortenGetters && ['script:post-response', 'tests'].includes(blockName)) {
-        unindented = shortenGetters(unindented)
+        const shortenGettersOutcome = shortenGetters(unindented)
+        if (shortenGettersOutcome.messages.length > 0) {
+            outcome.issues.push(...shortenGettersOutcome.messages)
+            unindented = shortenGettersOutcome.code
+        }
     }
 
     let reformatted
 
-    if (
-        (blockName === 'body:json' || blockName === 'body:graphql:vars') &&
-        config.jsonFormatter === 'jsonc-parser'
-    ) {
+    if (blockType === 'JSON' && config.jsonFormatter === 'jsonc-parser') {
         unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
         const edits = jsoncFormat(unindented, undefined, {tabSize: 2, insertSpaces: true})
         reformatted = applyEdits(unindented, edits)
@@ -143,7 +204,7 @@ async function formatBlock(fileContents, blockName, config) {
     } else {
         try {
             const opts = {...config.prettier}
-            if (blockName === 'body:graphql') {
+            if (blockType === 'GraphQL') {
                 opts.parser = 'graphql'
                 opts.bracketSpacing = true
                 unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
@@ -154,15 +215,24 @@ async function formatBlock(fileContents, blockName, config) {
                 unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
             }
             reformatted = await prettier.format(unindented, opts)
-            if (
-                blockName === 'body:graphql' ||
-                blockName === 'body:json' ||
-                blockName === 'body:graphql:vars'
-            ) {
+
+            if (blockType === 'GraphQL' || blockType === 'JSON') {
                 reformatted = unwrapDelimitedPlaceholders(reformatted)
             }
         } catch (e) {
-            outcome.errorMessage = `Prettier could not format ${blockName} because...\n${e.message}`
+            const fatalMessage = `Prettier could not format ${blockName} because...\n${e.message}`
+            const fatalIndex = outcome.issues.findIndex(issue => issue.fatal)
+            if (fatalIndex !== -1) {
+                // Update the existing fatal issue from ESLint with the slightly nicer format from Prettier
+                outcome.issues[fatalIndex].message = fatalMessage
+                return outcome
+            }
+            outcome.issues.push({
+                fatal: true,
+                fixable: false,
+                message: fatalMessage,
+                severity: 2,
+            })
             return outcome
         }
     }
@@ -174,7 +244,7 @@ async function formatBlock(fileContents, blockName, config) {
     while (bodyLines.length && bodyLines[bodyLines.length - 1].trim() === '') bodyLines.pop()
 
     // GraphQL formatter in Bruno always have exactly 1 line in the end
-    if (bodyLines.length > 0 && blockName === 'body:graphql') {
+    if (bodyLines.length > 0 && blockType === 'GraphQL') {
         bodyLines.push('')
     }
 
@@ -190,21 +260,52 @@ async function formatBlock(fileContents, blockName, config) {
 
     outcome.fileContents = fileContents.replace(rawBody, formattedBody)
     outcome.changeable = true
+    outcome.issues.push({
+        fixable: true,
+        message: `Badly formatted ${blockType}`,
+        severity: 2,
+    })
     return outcome
 }
 
 /**
- * @param {string} blockContents
- * @returns {string}
+ *
+ * @param {string} blockName
+ * @returns {("JavaScript"|"JSON"|"GraphQL")}
  */
-function shortenGetters(blockContents) {
+function calculateBlockType(blockName) {
+    if (blockName === 'body:graphql') {
+        return 'GraphQL'
+    }
+    if (blockName === 'body:json' || blockName === 'body:graphql:vars') {
+        return 'JSON'
+    }
+    // it must be script:post-response, script:pre-request or tests
+    return 'JavaScript'
+}
+
+/**
+ * @param {string} code
+ * @returns {{code: string, messages: Issue[]}}
+ */
+function shortenGetters(code) {
+    const outcome = {code, messages: []}
     const props = ['body', 'headers', 'responseTime', 'status', 'statusText', 'url']
     props.forEach(prop => {
         const getter = 'get' + prop.substring(0, 1).toUpperCase() + prop.substring(1)
         const getterRegex = new RegExp('(?<!\\w)res\.' + getter + '\\(\\)', 'g')
-        blockContents = blockContents.replaceAll(getterRegex, `res.${prop}`)
+        if (code.match(getterRegex)) {
+            const replacement = `res.${prop}`
+            outcome.messages.push({
+                fixable: true,
+                message: `res.${getter}() used instead of ${replacement}`,
+                severity: 2,
+            })
+            code = code.replaceAll(getterRegex, replacement)
+        }
     })
-    return blockContents
+    outcome.code = code
+    return outcome
 }
 
 /**
@@ -256,11 +357,14 @@ function stripEmptyBlock(fileContents, blockName) {
 }
 
 /**
+ * Searches for uses of @file(...) where the path argument uses Windows-specific back slashes
+ * instead of OS-agnostic forward slashes
+ *
  * @param {string} fileContents
- * @returns {{fileContents: string, changeable: boolean, errorMessage: ?string}}
+ * @returns {{fileContents: string, changeable: boolean, messages: Issue[]}}
  */
 function formatFilePaths(fileContents) {
-    let changeable = false
+    const outcome = {changeable: false, fileContents, messages: []}
 
     const matches = fileContents.matchAll(/file: @file\(([^)]+)\)/g)
 
@@ -268,12 +372,17 @@ function formatFilePaths(fileContents) {
         const path = match[1]
         if (path.match(/\\/) !== null) {
             const newPath = path.replaceAll('\\', '/')
-            changeable = true
-            fileContents = fileContents.replace(path, newPath)
+            outcome.changeable = true
+            outcome.fileContents = outcome.fileContents.replace(path, newPath)
+            outcome.messages.push({
+                fixable: true,
+                message: 'Back slash separators used in @file()',
+                severity: 2,
+            })
         }
     }
 
-    return {fileContents, changeable, errorMessage: null}
+    return outcome
 }
 
 /**

--- a/lib/lint.mjs
+++ b/lib/lint.mjs
@@ -1,0 +1,174 @@
+import {ESLint} from 'eslint'
+import {defineConfig} from 'eslint/config'
+import {styleText} from 'node:util'
+
+const defaultRules = {
+    'no-console': 'error',
+    'no-redeclare': 'error',
+    'no-sequences': 'error',
+    'no-unused-vars': 'error',
+    'no-var': 'error',
+    'prefer-arrow-callback': 'warn',
+    'prefer-const': 'warn',
+}
+
+/**
+ * Uses ESLint to lint JavaScript
+ *
+ * @param {Object} console The console to be used for outputting messages
+ * @param {('recommended'|Object|false)} rules ESLint rules
+ * @return {Promise<{esLintEngine: ?ESLint, fatalError: boolean}>}
+ */
+export async function loadESLintEngine(console, rules) {
+    const outcome = {esLintEngine: null, fatalError: false}
+
+    if (rules === false) {
+        return outcome
+    }
+
+    if (rules === 'recommended') {
+        rules = {...defaultRules}
+    }
+
+    if (Object.keys(rules).length === 0) {
+        return outcome
+    }
+
+    const options = {
+        overrideConfigFile: true,
+        overrideConfig: defineConfig({
+            name: '.prettifybrurc',
+            rules: rules,
+        }),
+    }
+
+    const esLintEngine = new ESLint(options)
+
+    // Test drive it with a lint to check the rules are valid
+    try {
+        await esLintEngine.lintText('function sayHello() { return "Hello" }')
+    } catch (error) {
+        const errorMessage = error.message.replace('Key "rules":', 'Key "esLintRules":')
+        console.error(`💥  ${styleText('red', `${errorMessage}`)}`)
+        outcome.fatalError = true
+        return outcome
+    }
+
+    outcome.esLintEngine = esLintEngine
+
+    return outcome
+}
+
+/**
+ * Uses ESLint to lint JavaScript
+ *
+ * @param {string} code The ECMAScript/JavaScript to be linted
+ * @param {ESLint} esLintEngine An instance of ESLint
+ * @param {boolean} fix
+ * @param {array} fixedMessages Messages from fixes already applied in outside recursions
+ * @return {Promise<{messages: import('./format.mjs').Issue[], code: string}>}
+ */
+export async function lint(code, esLintEngine, fix, fixedMessages = []) {
+    let outcome = {messages: [], code: code}
+
+    const lintResults = await esLintEngine.lintText(code)
+
+    for (const result of lintResults) {
+        for (const m of result.messages) {
+            if (
+                m.ruleId === 'prefer-arrow-callback' &&
+                m.message === 'Unexpected function expression.'
+            ) {
+                m.message += ' Use () => instead.'
+            }
+            // console.log(m)
+            const fixResult = attemptFix(code, m)
+
+            let message = `(${m.line}:${m.column}) ${m.message}`
+            if (m.suggestions && m.suggestions.length) {
+                message = `${message} ${m.suggestions[0].desc}`
+            }
+            const issue = {
+                fixable: fixResult.fixable,
+                message: message,
+                severity: m.severity,
+            }
+            if (m.fatal === true) {
+                issue.fatal = true
+            }
+            outcome.messages.push(issue)
+
+            if (fixResult.fixable) {
+                // Update the outcome with the fix
+                outcome.code = fixResult.code
+
+                if (fix) {
+                    // Because this fix has modified the code we need to recursively call the linting
+                    return lint(outcome.code, esLintEngine, fix, [
+                        ...fixedMessages,
+                        outcome.messages.pop(),
+                    ])
+                }
+            }
+        }
+    }
+
+    // Now we're passed the point of recursion, we know this is the final call so mix in the fixes from outside calls
+    outcome.messages = [...outcome.messages, ...fixedMessages]
+
+    return outcome
+}
+
+/**
+ * @param {string} code
+ * @param {Object} message A message from ESLint.LintResult.messages
+ * @returns {{code: string, fixable: boolean}}
+ */
+function attemptFix(code, message) {
+    const fix = findFix(message)
+
+    if (fix === null) {
+        return {code: code, fixable: false}
+    }
+
+    let fixed = applyFix(code, fix)
+
+    // console.log('--------------')
+    // console.log(message.line, fix)
+    // console.log('--------------')
+    // console.log(code)
+    // console.log('--------------')
+    // console.log(fixed)
+    // console.log('--------------\n')
+
+    return {code: fixed, fixable: true}
+}
+
+/**
+ * @param {Object} message
+ * @returns {?{text: string, range: number[]}}
+ */
+function findFix(message) {
+    if (
+        Object.hasOwn(message, 'suggestions') &&
+        message.suggestions.length &&
+        Object.hasOwn(message.suggestions[0], 'fix')
+    ) {
+        return message.suggestions[0].fix
+    }
+
+    if (Object.hasOwn(message, 'fix')) {
+        return message.fix
+    }
+
+    return null
+}
+
+/**
+ * @param {string} code
+ * @param {{text: string, range: number[]}} fix
+ * @returns {string}
+ */
+function applyFix(code, fix) {
+    return code.substring(0, fix.range[0]) + fix.text + code.substring(fix.range[1])
+}

--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -3,6 +3,7 @@ import {format} from './format.mjs'
 import {validateOnlyParam} from './onlyParam.mjs'
 import {loadConfigFile} from './config.mjs'
 import {styleText} from 'node:util'
+import {loadESLintEngine} from './lint.mjs'
 
 /**
  * Finds all .bru files and formats contents
@@ -34,56 +35,89 @@ export async function main(console, cwd, path, write, only = null, cliConfig = {
 
     const config = {...loadConfigFile(console), ...cliConfig}
 
-    let changeableFiles = []
-    let erroredFiles = []
+    let ruleset = 'recommended'
+    if (Object.hasOwn(config, 'esLintRules')) {
+        ruleset = config.esLintRules
+        delete config.esLintRules
+    }
+    const loadEngineOutcome = await loadESLintEngine(console, ruleset)
+    if (loadEngineOutcome.fatalError) {
+        return true
+    }
+    const esLintEngine = loadEngineOutcome.esLintEngine
+
+    const changeableFiles = []
+    const erroredFiles = []
+    let requireNothing = 0
 
     for (const filePath of files) {
-        const outcome = await processFile(filePath, write, only, config)
+        const outcome = await processFile(filePath, write, only, config, esLintEngine)
 
         let displayFilePath = filePath.replace(new RegExp('^' + cwd + '/'), '')
 
         if (outcome.changeable) {
             changeableFiles.push({displayFilePath, outcome})
-        } else if (outcome.errorMessages.length) {
+        }
+        if (outcome.blockReports.length) {
             erroredFiles.push({displayFilePath, outcome})
+        }
+        if (!outcome.changeable && outcome.blockReports.length === 0) {
+            requireNothing++
         }
     }
 
-    const changeableSuffix = write ? 'reformatted' : 'require reformatting'
+    const changeableSuffix = write ? 'had fixes applied 🪛' : 'can have issues auto-fixed 🪛'
     let changeableReport = null
-    const changeableColor = write ? 'green' : 'yellow'
+    const changeableColor = write ? 'green' : 'white'
     if (changeableFiles.length) {
-        const emoji = write ? '✏️' : '⚠️'
+        const emoji = write ? '✏️' : '👎️'
         const changeableFilesDesc = fileDesc(changeableFiles)
         changeableReport = `${changeableFilesDesc} ${changeableSuffix}`
-        console.log(styleText([changeableColor, 'underline'], `${changeableReport}:\n`))
-        changeableFiles.forEach(r =>
-            console.log(`${emoji}  ${styleText(changeableColor, r.displayFilePath)}`)
-        )
-        console.log(' ')
     }
 
+    let totalErrorCount = 0
     let erroredReport = null
     if (erroredFiles.length) {
         const erroredFilesDesc = fileDesc(erroredFiles)
-        erroredReport = `${erroredFilesDesc} causing errors`
+        erroredReport = erroredFilesDesc + ' contained issues'
         console.warn(styleText(['red', 'underline'], `${erroredReport}:\n`))
         erroredFiles.forEach((r, i) => {
             console.warn(`${i + 1}) ${r.displayFilePath}\n`)
-            r.outcome.errorMessages.forEach(err => {
-                console.warn(`❌ ${styleText('red', err)}\n`)
+            r.outcome.blockReports.forEach(errs => {
+                let log = '  '
+                if (errs.blockName !== null) {
+                    log += `${errs.blockName} block `
+                }
+                log += `has ${errs.issues.length} issue`
+                log += errs.issues.length > 1 ? 's' : ''
+                log += '...'
+                errs.issues.forEach(err => {
+                    if (err.severity === 2) {
+                        totalErrorCount++
+                    }
+                    const icon = err.severity === 2 ? '❌' : '⚠️ '
+                    const col = err.severity === 2 ? 'red' : 'yellowBright'
+                    let fixable = ''
+                    if (err.fixable) {
+                        fixable = ' [🪛 '
+                        fixable += write ? styleText('green', 'Fixed!') : 'Auto-fixable'
+                        fixable += ']'
+                    }
+                    const indentedErrorMessage = err.message.replace(/\n/g, '\n       ')
+                    log = `${log}\n    ${icon} ${styleText(col, indentedErrorMessage)}${fixable}`
+                })
+                console.warn(`${log} \n`)
             })
         })
     }
 
-    const requireNothing = files.length - changeableFiles.length - erroredFiles.length
     const filesDesc = fileDesc(files)
     console.log(`Inspected ${filesDesc}:`)
-    if (changeableReport) {
-        console.log(styleText(changeableColor, `  ${changeableReport}`))
-    }
     if (erroredReport) {
         console.log(styleText('red', `  ${erroredReport}`))
+    }
+    if (changeableReport) {
+        console.log(styleText(changeableColor, `  ${changeableReport}`))
     }
     if (requireNothing > 0) {
         const requireNothingColor = requireNothing === files.length ? 'green' : 'dim'
@@ -93,7 +127,7 @@ export async function main(console, cwd, path, write, only = null, cliConfig = {
         )
     }
 
-    return erroredFiles.length > 0 || changeableFiles.length > 0
+    return totalErrorCount > 0
 }
 
 function fileDesc(files) {
@@ -105,12 +139,13 @@ function fileDesc(files) {
  * @param {boolean} write
  * @param {?string} only Limit to only the block type with a name containing value
  * @param {Object} config
- * @returns {Promise<FileOutcome>}
+ * @param {?import('eslint').ESLint} esLintEngine
+ * @returns {Promise<import('./format.mjs').FileOutcome>}
  */
-async function processFile(filePath, write, only, config) {
+async function processFile(filePath, write, only, config, esLintEngine) {
     const original = readFile(filePath)
 
-    const fileOutcome = await format(original, only, config)
+    const fileOutcome = await format(original, only, config, esLintEngine, write)
 
     if (write && fileOutcome.changeable) {
         writeFile(filePath, fileOutcome.newContents)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "eslint": "~10.0.3",
         "jsonc-parser": "^3.3.1",
         "prettier": "^3.3.3",
         "yargs": "18.0.0"
@@ -549,6 +550,189 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1151,6 +1335,18 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1177,6 +1373,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.0.3",
@@ -1487,6 +1689,43 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1919,7 +2158,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1934,7 +2172,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1962,6 +2199,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -2045,6 +2288,202 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2057,6 +2496,48 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -2118,11 +2599,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
     "node_modules/fb-watchman": {
@@ -2133,6 +2625,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -2161,6 +2665,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2276,6 +2799,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2310,6 +2845,15 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2334,7 +2878,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2366,6 +2909,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2384,6 +2936,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -2413,7 +2977,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3279,11 +3842,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -3305,6 +3886,15 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3313,6 +3903,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3445,7 +4048,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -3468,7 +4070,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-int64": {
@@ -3534,11 +4135,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -3619,7 +4236,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3639,7 +4255,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3712,6 +4327,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
@@ -3753,6 +4377,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
@@ -3826,7 +4459,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3839,7 +4471,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4199,6 +4830,18 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4295,6 +4938,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -4324,7 +4976,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4334,6 +4985,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4500,7 +5160,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prettify-bru",
   "version": "1.10.0",
-  "description": "Prettifies JSON, JavaScript and GraphQL blocks in Bruno .bru files",
+  "description": "Lints and prettifies JSON, JavaScript and GraphQL blocks in Bruno .bru files",
   "keywords": [
     "bruno",
     "bru",
@@ -28,6 +28,7 @@
   ],
   "bin": "./cli.js",
   "dependencies": {
+    "eslint": "~10.0.3",
     "jsonc-parser": "^3.3.1",
     "prettier": "^3.3.3",
     "yargs": "18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettify-bru",
-  "version": "1.10.0",
+  "version": "2.0.0-beta.0",
   "description": "Lints and prettifies JSON, JavaScript and GraphQL blocks in Bruno .bru files",
   "keywords": [
     "bruno",

--- a/test/config/config_parse_file.test.js
+++ b/test/config/config_parse_file.test.js
@@ -74,6 +74,45 @@ describe('parseFile() function in config module', () => {
         expect(config).toEqual({})
     })
 
+    // Coverage of eslint property...
+
+    it('logs if user has not configured `esLintRules`', () => {
+        const mockConsole = {log: jest.fn()}
+        // This config file does not set the esLintRules property
+        parseFile(mockConsole, '{}')
+
+        expect(mockConsole.log).toHaveBeenCalledTimes(3)
+        expect(mockConsole.log).toHaveBeenNthCalledWith(
+            2,
+            `   ${styleText('dim', `"esLintRules" is not set. Defaulting to recommended ruleset.`)}`
+        )
+    })
+
+    it('warns if `esLintRules` is neither an object or false', () => {
+        const mockConsole = {log: jest.fn(), warn: jest.fn()}
+        // This config incorrectly provides an array for the esLintRules property
+        const config = parseFile(mockConsole, '{"esLintRules": [1, 2]}')
+
+        expect(mockConsole.warn).toHaveBeenCalledWith(
+            `⚠️  ${styleText('yellow', '"esLintRules" is not correct type, it should be the string "recommended" or an object or false')}`
+        )
+        expect(config).toEqual({})
+    })
+
+    it.each([false, 'recommended', {'no-console': 'warn'}])(
+        'accepts all types of value for esLintRules property',
+        val => {
+            const mockConsole = {log: jest.fn(), warn: jest.fn()}
+            const fileContents = JSON.stringify({esLintRules: val})
+            const config = parseFile(mockConsole, fileContents)
+
+            expect(mockConsole.warn).not.toHaveBeenCalled()
+            expect(config).toEqual({esLintRules: val})
+        }
+    )
+
+    // Coverage of unsupported properties...
+
     it('warns on unsupported properties', () => {
         const mockConsole = {log: jest.fn(), warn: jest.fn()}
         const config = parseFile(mockConsole, '{"fish": "horse"}')
@@ -83,6 +122,8 @@ describe('parseFile() function in config module', () => {
         )
         expect(config).toEqual({})
     })
+
+    // Coverage of transferring properties from file to config object...
 
     it('transfers `agnosticFilePaths` property', () => {
         const mockConsole = {log: jest.fn()}

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,5 +1,6 @@
-import {describe, expect, it} from '@jest/globals'
+import {describe, expect, it, jest} from '@jest/globals'
 import {format} from '../lib/format'
+import {loadESLintEngine} from '../lib/lint.mjs'
 
 describe('The format() function', () => {
     it('reformats JSON and JavaScript blocks', async () => {
@@ -17,7 +18,7 @@ describe('The format() function', () => {
             '',
             'script:pre-request {',
             '      go().then(() => {',
-            "         console.log('Hello World');", // Too much indentation, wrong type of quotes and a semi-colon
+            "         bru.setVar('message', 'Hello World');", // Too much indentation, wrong type of quotes and a semi-colon
             '    })',
             '}',
             '',
@@ -37,8 +38,105 @@ describe('The format() function', () => {
             '',
             'script:pre-request {',
             '  go().then(() => {',
-            '    console.log("Hello World")',
+            '    bru.setVar("message", "Hello World")',
             '  })',
+            '}',
+            '',
+        ].join('\n')
+
+        expect.assertions(7)
+        return format(originalFileContents).then(result => {
+            expect(result.changeable).toBe(true)
+            expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(2)
+            expect(result.blockReports[0].blockName).toBe('body:json')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted JSON',
+                    severity: 2,
+                },
+            ])
+            expect(result.blockReports[1].blockName).toBe('script:pre-request')
+            expect(result.blockReports[1].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted JavaScript',
+                    severity: 2,
+                },
+            ])
+        })
+    })
+
+    it('removes excess whitespace from body:json', async () => {
+        const originalFileContents = [
+            '',
+            'body:json {',
+            '  ', // <-- Excess blank line
+            '  {',
+            '    "leafType": "variegated",',
+            '    ', // <-- Excess blank line
+            '    "stemCount": 134',
+            '    ', // <-- Excess blank line
+            '  }',
+            '  ', // <-- Excess blank line
+            '}',
+            '',
+        ].join('\n')
+
+        const expected = [
+            '',
+            'body:json {',
+            '  {',
+            '    "leafType": "variegated",',
+            '    "stemCount": 134',
+            '  }',
+            '}',
+            '',
+        ].join('\n')
+
+        expect.assertions(5)
+        return format(originalFileContents).then(result => {
+            expect(result.changeable).toBe(true)
+            expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:json')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted JSON',
+                    severity: 2,
+                },
+            ])
+        })
+    })
+
+    it('removes excess lines between blocks', async () => {
+        const originalFileContents = [
+            '',
+            'body:json {',
+            '  {',
+            '    "suspect": "Bernie Tiede"',
+            '  }',
+            '}',
+            '',
+            '', // <-- Excess blank line
+            'script:post-response {',
+            '  bru.setVar("foo", "bar")',
+            '}',
+            '',
+        ].join('\n')
+
+        const expected = [
+            '',
+            'body:json {',
+            '  {',
+            '    "suspect": "Bernie Tiede"',
+            '  }',
+            '}',
+            '',
+            'script:post-response {',
+            '  bru.setVar("foo", "bar")',
             '}',
             '',
         ].join('\n')
@@ -46,8 +144,19 @@ describe('The format() function', () => {
         expect.assertions(3)
         return format(originalFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports).toStrictEqual([
+                {
+                    blockName: null,
+                    issues: [
+                        {
+                            fixable: true,
+                            message: 'Excess lines between blocks',
+                            severity: 2,
+                        },
+                    ],
+                },
+            ])
         })
     })
 
@@ -83,12 +192,6 @@ describe('The format() function', () => {
             '  }',
             '}',
             '',
-            'script:pre-request {',
-            '      go().then(() => {',
-            "         console.log('Hello World');", // Too much indentation, wrong type of quotes and a semi-colon
-            '    })',
-            '}',
-            '',
         ].join('\n')
 
         const expected = [
@@ -120,19 +223,19 @@ describe('The format() function', () => {
             '  ', // There is empty line added by the GraphQL formatter in Bruno
             '}',
             '',
-            'script:pre-request {',
-            '  go().then(() => {',
-            '    console.log("Hello World")',
-            '  })',
-            '}',
-            '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(originalFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:graphql')
+            expect(result.blockReports[0].issues[0]).toStrictEqual({
+                fixable: true,
+                message: 'Badly formatted GraphQL',
+                severity: 2,
+            })
         })
     })
 
@@ -156,12 +259,6 @@ describe('The format() function', () => {
             '  ',
             '}',
             '',
-            'script:pre-request {',
-            '      go().then(() => {',
-            "         console.log('Hello World');", // Too much indentation, wrong type of quotes and a semi-colon
-            '    })',
-            '}',
-            '',
         ].join('\n')
 
         const expected = [
@@ -178,19 +275,21 @@ describe('The format() function', () => {
             '  ', // There is empty line added by the GraphQL formatter in Bruno
             '}',
             '',
-            'script:pre-request {',
-            '  go().then(() => {',
-            '    console.log("Hello World")',
-            '  })',
-            '}',
-            '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(originalFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:graphql')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted GraphQL',
+                    severity: 2,
+                },
+            ])
         })
     })
 
@@ -206,7 +305,7 @@ describe('The format() function', () => {
         expect.assertions(3)
         return format(originalFileContents).then(result => {
             expect(result.changeable).toBe(false)
-            expect(result.errorMessages).toStrictEqual([])
+            expect(result.blockReports).toStrictEqual([])
             expect(result.newContents).toBe(originalFileContents)
         })
     })
@@ -235,7 +334,7 @@ describe('The format() function', () => {
         return format(originalFileContents).then(result => {
             expect(result.newContents).toBe(originalFileContents)
             expect(result.changeable).toBe(false)
-            expect(result.errorMessages).toStrictEqual([])
+            expect(result.blockReports).toStrictEqual([])
         })
     })
 
@@ -278,11 +377,17 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(originalFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:json')
+            expect(result.blockReports[0].issues[0]).toStrictEqual({
+                fixable: true,
+                message: 'Badly formatted JSON',
+                severity: 2,
+            })
         })
     })
 
@@ -310,27 +415,42 @@ describe('The format() function', () => {
                 '',
             ].join('\n')
 
-            expect.assertions(3)
+            expect.assertions(5)
             return format(originalFileContents).then(result => {
                 expect(result.newContents).toBe(expected)
-                expect(result.errorMessages).toStrictEqual([])
                 expect(result.changeable).toBe(true)
+                expect(result.blockReports.length).toBe(1)
+                expect(result.blockReports[0].blockName).toBe(blockName)
+                expect(result.blockReports[0].issues[0]).toStrictEqual({
+                    fixable: true,
+                    message: 'Badly formatted JSON',
+                    severity: 2,
+                })
             })
         }
     )
 
     it.each(['script:pre-request', 'script:post-response', 'tests'])(
-        'returns an error message when Prettier cannot format %s block',
+        'returns exactly 1 fatal issue for unparsable JavaScript in %s block',
         async blockName => {
             const invalidJs = 'const x = {'
             const originalFileContents = ['', `${blockName} {`, `  ${invalidJs}`, '}', ''].join(
                 '\n'
             )
 
-            expect.assertions(3)
-            return format(originalFileContents).then(result => {
-                expect(result.errorMessages).toHaveLength(1)
-                expect(result.errorMessages[0]).toContain(
+            const mockConsole = {error: jest.fn()}
+            const loadEngineOutcome = await loadESLintEngine(mockConsole, 'recommended')
+            const esLintEngine = loadEngineOutcome.esLintEngine
+
+            expect.assertions(8)
+            return format(originalFileContents, null, {}, esLintEngine).then(result => {
+                expect(result.blockReports).toHaveLength(1)
+                expect(result.blockReports[0].blockName).toBe(blockName)
+                expect(result.blockReports[0].issues.length).toBe(1)
+                expect(result.blockReports[0].issues[0].fatal).toBe(true)
+                expect(result.blockReports[0].issues[0].fixable).toBe(false)
+                expect(result.blockReports[0].issues[0].severity).toBe(2)
+                expect(result.blockReports[0].issues[0].message).toContain(
                     `Prettier could not format ${blockName} because...\nUnexpected token (1:12)`
                 )
                 expect(result.changeable).toBe(false)
@@ -342,10 +462,11 @@ describe('The format() function', () => {
         const invalidJs = 'const x = {'
         const originalFileContents = ['', `body:graphql {`, `  ${invalidJs}`, '}', ''].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(4)
         return format(originalFileContents).then(result => {
-            expect(result.errorMessages).toHaveLength(1)
-            expect(result.errorMessages[0]).toContain(
+            expect(result.blockReports).toHaveLength(1)
+            expect(result.blockReports[0].blockName).toBe('body:graphql')
+            expect(result.blockReports[0].issues[0].message).toContain(
                 `Prettier could not format body:graphql because...\nSyntax Error: Unexpected Name "const". (1:1)`
             )
             expect(result.changeable).toBe(false)
@@ -378,11 +499,19 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(originalFileContents).then(result => {
             expect(result.newContents).toBe(expected)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.changeable).toBe(true)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:json')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted JSON',
+                    severity: 2,
+                },
+            ])
         })
     })
 
@@ -518,7 +647,7 @@ describe('The format() function', () => {
             return format(correctlyFormattedFileContents).then(result => {
                 expect(result.newContents).toBe(correctlyFormattedFileContents)
                 expect(result.changeable).toBe(false)
-                expect(result.errorMessages).toStrictEqual([])
+                expect(result.blockReports).toStrictEqual([])
             })
         }
     )
@@ -575,11 +704,19 @@ describe('The format() function', () => {
                 '',
             ].join('\n')
 
-            expect.assertions(3)
+            expect.assertions(5)
             return format(badlyFormattedFileContents).then(result => {
                 expect(result.changeable).toBe(true)
-                expect(result.errorMessages).toStrictEqual([])
                 expect(result.newContents).toBe(expected)
+                expect(result.blockReports.length).toBe(1)
+                expect(result.blockReports[0].blockName).toBe(blockName)
+                expect(result.blockReports[0].issues).toStrictEqual([
+                    {
+                        fixable: true,
+                        message: 'Badly formatted JSON',
+                        severity: 2,
+                    },
+                ])
             })
         }
     )
@@ -642,10 +779,19 @@ describe('The format() function', () => {
                 '',
             ].join('\n')
 
-            expect.assertions(3)
+            expect.assertions(6)
             return format(badlyFormattedFileContents).then(result => {
                 expect(result.changeable).toBe(true)
-                expect(result.errorMessages).toStrictEqual([])
+                expect(result.blockReports.length).toBe(1)
+                expect(result.blockReports[0].blockName).toBe(blockName)
+                expect(result.blockReports[0].issues.length).toBe(1)
+                expect(result.blockReports[0].issues).toStrictEqual([
+                    {
+                        fixable: true,
+                        severity: 2,
+                        message: 'Badly formatted JSON',
+                    },
+                ])
                 expect(result.newContents).toBe(expected)
             })
         }
@@ -695,11 +841,19 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(badlyFormattedFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:graphql')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted GraphQL',
+                    severity: 2,
+                },
+            ])
         })
     })
 
@@ -744,11 +898,19 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(5)
         return format(badlyFormattedFileContents).then(result => {
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
             expect(result.newContents).toBe(expected)
+            expect(result.blockReports.length).toBe(1)
+            expect(result.blockReports[0].blockName).toBe('body:graphql')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'Badly formatted GraphQL',
+                    severity: 2,
+                },
+            ])
         })
     })
 
@@ -781,7 +943,7 @@ describe('The format() function', () => {
         return format(correctlyFormattedFileContents).then(result => {
             expect(result.newContents).toBe(correctlyFormattedFileContents)
             expect(result.changeable).toBe(false)
-            expect(result.errorMessages).toStrictEqual([])
+            expect(result.blockReports).toStrictEqual([])
         })
     })
 
@@ -900,11 +1062,12 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(4)
         return format(originalFileContents).then(result => {
             expect(result.newContents).toBe(expected)
             expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
+            expect(result.blockReports.length).toEqual(1)
+            expect(result.blockReports[0].blockName).toEqual('body:file')
         })
     })
 
@@ -931,12 +1094,12 @@ describe('The format() function', () => {
         const originalFileContents = [
             '',
             'script:post-response {',
-            '  console.log(res.getHeaders())',
-            '  console.log(acres.getBody().farm)', // This line should not be changed
+            '  bru.setVar("headers", res.getHeaders())',
+            '  bru.setVar("farm", acres.getBody().farm)', // This line should not be changed
             '}',
             '',
             'tests {',
-            '  console.log(req.getBody({raw: true}))', // This line should not be changed
+            '  bru.setVar("rawBody", req.getBody({raw: true}))', // This line should not be changed
             '  expect(res.getStatusText()).to.eql("OK")',
             '  expect(res.getStatus()).to.eql(200)',
             '  expect(res.getBody().name).to.eql("Dave")',
@@ -947,12 +1110,12 @@ describe('The format() function', () => {
         const expected = [
             '',
             'script:post-response {',
-            '  console.log(res.headers)',
-            '  console.log(acres.getBody().farm)',
+            '  bru.setVar("headers", res.headers)',
+            '  bru.setVar("farm", acres.getBody().farm)',
             '}',
             '',
             'tests {',
-            '  console.log(req.getBody({raw: true}))',
+            '  bru.setVar("rawBody", req.getBody({raw: true}))',
             '  expect(res.statusText).to.eql("OK")',
             '  expect(res.status).to.eql(200)',
             '  expect(res.body.name).to.eql("Dave")',
@@ -960,11 +1123,46 @@ describe('The format() function', () => {
             '',
         ].join('\n')
 
-        expect.assertions(3)
+        expect.assertions(6)
         return format(originalFileContents).then(result => {
             expect(result.newContents).toBe(expected)
-            expect(result.changeable).toBe(true)
-            expect(result.errorMessages).toStrictEqual([])
+            expect(result.blockReports.length).toBe(2)
+            expect(result.blockReports[0].blockName).toBe('script:post-response')
+            expect(result.blockReports[0].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'res.getHeaders() used instead of res.headers',
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: 'Badly formatted JavaScript',
+                    severity: 2,
+                },
+            ])
+            expect(result.blockReports[1].blockName).toBe('tests')
+            expect(result.blockReports[1].issues).toStrictEqual([
+                {
+                    fixable: true,
+                    message: 'res.getBody() used instead of res.body',
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: 'res.getStatus() used instead of res.status',
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: 'res.getStatusText() used instead of res.statusText',
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: 'Badly formatted JavaScript',
+                    severity: 2,
+                },
+            ])
         })
     })
 
@@ -1017,10 +1215,17 @@ describe('The format() function', () => {
 
             const config = {jsonFormatter: 'prettier'}
 
-            expect.assertions(3)
+            expect.assertions(4)
             return format(originalFileContents, null, config).then(result => {
                 expect(result.newContents).toBe(withoutTrailingCommas)
-                expect(result.errorMessages).toStrictEqual([])
+                expect(result.blockReports[0].blockName).toBe(blockName)
+                expect(result.blockReports[0].issues).toStrictEqual([
+                    {
+                        fixable: true,
+                        message: 'Badly formatted JSON',
+                        severity: 2,
+                    },
+                ])
                 expect(result.changeable).toBe(true)
             })
         }
@@ -1032,10 +1237,14 @@ describe('The format() function', () => {
 
         const config = {jsonFormatter: 'prettier'}
 
-        expect.assertions(2)
+        expect.assertions(6)
         return format(originalFileContents, null, config).then(result => {
-            expect(result.errorMessages).toHaveLength(1)
-            expect(result.errorMessages[0]).toContain(
+            expect(result.blockReports).toHaveLength(1)
+            expect(result.blockReports[0].blockName).toBe('body:json')
+            expect(result.blockReports[0].issues).toHaveLength(1)
+            expect(result.blockReports[0].issues[0].fatal).toBe(true)
+            expect(result.blockReports[0].issues[0].fixable).toBe(false)
+            expect(result.blockReports[0].issues[0].message).toContain(
                 'Prettier could not format body:json because...'
             )
         })

--- a/test/format/format_lint.test.js
+++ b/test/format/format_lint.test.js
@@ -1,0 +1,49 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {loadESLintEngine} from '../../lib/lint'
+import {format} from '../../lib/format'
+
+describe('The format() calling lint() function', () => {
+    it('with 1 ESLint rule', async () => {
+        const fileContents = [
+            'meta {',
+            '  name: Call to licorice',
+            '}',
+            '',
+            'body:json {',
+            '  {',
+            '    "style": "lace"',
+            '  }',
+            '}',
+            '',
+            'script:post-response {',
+            '  var message = "Hello World"', // This unused var would fail the recommended ruleset, but not users custom ruleset
+            '  console.log("Hello World")',
+            '}',
+            '',
+        ].join('\n')
+
+        const mockConsole = {error: jest.fn()}
+        const loadEngineOutcome = await loadESLintEngine(mockConsole, {
+            'no-console': 'error',
+        })
+        const esLintEngine = loadEngineOutcome.esLintEngine
+
+        expect.assertions(2)
+        return format(fileContents, null, {}, esLintEngine).then(result => {
+            expect(result.changeable).toBe(true)
+            expect(result.blockReports).toStrictEqual([
+                {
+                    blockName: 'script:post-response',
+                    issues: [
+                        {
+                            fixable: true,
+                            message:
+                                '(2:1) Unexpected console statement. Remove the console.log().',
+                            severity: 2,
+                        },
+                    ],
+                },
+            ])
+        })
+    })
+})

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -1,0 +1,137 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {loadESLintEngine, lint} from '../lib/lint'
+import {styleText} from 'node:util'
+
+describe('loadESLintEngine()', () => {
+    it('reports fatal error on invalid rules', async () => {
+        const mockConsole = {error: jest.fn()}
+        const invalidRules = {
+            'no-tomato-in-burgers': 'error', // This is NOT a real ESLint rule
+        }
+
+        expect.assertions(3)
+        return loadESLintEngine(mockConsole, invalidRules).then(loadEngineOutcome => {
+            expect(loadEngineOutcome.fatalError).toEqual(true)
+            expect(loadEngineOutcome.esLintEngine).toBeNull()
+            expect(mockConsole.error).toHaveBeenCalledWith(
+                `💥  ${styleText('red', `Key "esLintRules": Key "no-tomato-in-burgers": Could not find "no-tomato-in-burgers" in plugin "@".`)}`
+            )
+        })
+    })
+
+    it('reports fatal error on value for rule', async () => {
+        const mockConsole = {error: jest.fn()}
+        const invalidRules = {
+            'no-console': 'warning', // "warning" is NOT a valid value
+        }
+
+        expect.assertions(3)
+        return loadESLintEngine(mockConsole, invalidRules).then(loadEngineOutcome => {
+            expect(loadEngineOutcome.fatalError).toEqual(true)
+            expect(loadEngineOutcome.esLintEngine).toBeNull()
+            expect(mockConsole.error).toHaveBeenCalledWith(
+                `💥  ${styleText('red', `Config ".prettifybrurc": Key "esLintRules": Key "no-console": Expected severity of "off", 0, "warn", 1, "error", or 2.`)}`
+            )
+        })
+    })
+
+    it('honours esLintRules set to false', async () => {
+        const mockConsole = {error: jest.fn()}
+        const esLintRules = false // false means do not lint
+
+        expect.assertions(3)
+        return loadESLintEngine(mockConsole, esLintRules).then(loadEngineOutcome => {
+            expect(loadEngineOutcome.fatalError).toEqual(false)
+            expect(loadEngineOutcome.esLintEngine).toBeNull()
+            expect(mockConsole.error).not.toHaveBeenCalled()
+        })
+    })
+})
+
+describe('The lint() function', () => {
+    it('uses recommended ruleset', async () => {
+        const mockConsole = {error: jest.fn()}
+        const loadEngineOutcome = await loadESLintEngine(mockConsole, 'recommended')
+        const esLintEngine = loadEngineOutcome.esLintEngine
+
+        const code = [
+            'const sausage = "Dog"', // Breaks no-unused-vars rule
+            'var message = "Hello World"', // Breaks no-var rule
+            'var message = "Howdy Earth"', // Breaks both the no-var and no-redeclare rules
+            'console.log(message)', // Breaks the no-console rule
+            'test("Response code is 200", function () {', // Breaks prefer-arrow-callback rule
+            '  let status = res.status', // Breaks the prefer-const rule
+            '  expect(status).to.be(200)',
+            '})',
+        ].join('\n')
+
+        expect.assertions(1)
+        return lint(code, esLintEngine).then(result => {
+            expect(result.messages).toStrictEqual([
+                {
+                    fixable: true,
+                    message:
+                        "(1:7) 'sausage' is assigned a value but never used. Remove unused variable 'sausage'.",
+                    severity: 2,
+                },
+                {
+                    fixable: false,
+                    message: '(2:1) Unexpected var, use let or const instead.',
+                    severity: 2,
+                },
+                {
+                    fixable: false,
+                    message: '(3:1) Unexpected var, use let or const instead.',
+                    severity: 2,
+                },
+                {
+                    fixable: false,
+                    message: "(3:5) 'message' is already defined.",
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: '(4:1) Unexpected console statement. Remove the console.log().',
+                    severity: 2,
+                },
+                {
+                    fixable: true,
+                    message: '(5:30) Unexpected function expression. Use () => instead.',
+                    severity: 1,
+                },
+                {
+                    fixable: true,
+                    message: "(6:7) 'status' is never reassigned. Use 'const' instead.",
+                    severity: 1,
+                },
+            ])
+        })
+    })
+
+    it('uses override ruleset containing only 1 warn-level', async () => {
+        const mockConsole = {error: jest.fn()}
+        const rules = {
+            'no-console': 'warn',
+        }
+
+        const loadEngineOutcome = await loadESLintEngine(mockConsole, rules)
+        const esLintEngine = loadEngineOutcome.esLintEngine
+
+        const code = [
+            'const sausage = "Dog"',
+            'var message = "Hello World"',
+            'console.log(message)',
+        ].join('\n')
+
+        expect.assertions(1)
+        return lint(code, esLintEngine).then(result => {
+            expect(result.messages).toStrictEqual([
+                {
+                    fixable: true,
+                    message: '(3:1) Unexpected console statement. Remove the console.log().',
+                    severity: 1,
+                },
+            ])
+        })
+    })
+})

--- a/test/main/main_does_not_write_file.test.js
+++ b/test/main/main_does_not_write_file.test.js
@@ -1,4 +1,5 @@
 import {jest, test, expect} from '@jest/globals'
+import {styleText} from 'node:util'
 
 test('main() does not write file when write mode is false', async () => {
     jest.unstable_mockModule('../../lib/files.mjs', () => ({
@@ -16,5 +17,10 @@ test('main() does not write file when write mode is false', async () => {
 
     return main(mockConsole, '/home', 'bruno-collection', false).then(() => {
         expect(writeFile).not.toHaveBeenCalled()
+        expect(mockConsole.log).toHaveBeenNthCalledWith(1, 'Inspected 1 file:')
+        expect(mockConsole.log).toHaveBeenNthCalledWith(
+            2,
+            `  ${styleText('green', '1 file did not require any changes')}`
+        )
     })
 })

--- a/test/main/main_passes_only.test.js
+++ b/test/main/main_passes_only.test.js
@@ -9,10 +9,17 @@ test('main() passes `only` parameter through to format()', async () => {
     }))
 
     jest.unstable_mockModule('../../lib/format.mjs', () => ({
-        format: jest.fn().mockName('mockformat').mockReturnValue({
+        format: jest.fn().mockName('mockFormat').mockReturnValue({
             newContents: 'New file contents',
             changeable: 1,
-            errorMessages: [],
+            blockReports: [],
+        }),
+    }))
+
+    jest.unstable_mockModule('../../lib/lint.mjs', () => ({
+        loadESLintEngine: jest.fn().mockName('mockLoadESLintEngine').mockReturnValue({
+            esLintEngine: null,
+            fatalError: false,
         }),
     }))
 
@@ -23,6 +30,12 @@ test('main() passes `only` parameter through to format()', async () => {
     const mockConsole = {log: jest.fn()}
 
     return main(mockConsole, '/dir', 'collection', false, 'body:json').then(() => {
-        expect(format).toHaveBeenCalledWith('mock original file contents', 'body:json', {})
+        expect(format).toHaveBeenCalledWith(
+            'mock original file contents',
+            'body:json',
+            {},
+            null,
+            false
+        )
     })
 })

--- a/test/main/main_writes_file.test.js
+++ b/test/main/main_writes_file.test.js
@@ -1,4 +1,5 @@
 import {jest, test, expect} from '@jest/globals'
+import {styleText} from 'node:util'
 
 test('main() writes file when write mode is true', async () => {
     jest.unstable_mockModule('../../lib/files.mjs', () => ({
@@ -17,7 +18,14 @@ test('main() writes file when write mode is true', async () => {
         format: jest.fn().mockName('mockformat').mockReturnValue({
             newContents: 'New file contents',
             changeable: true,
-            errorMessages: [],
+            blockReports: [],
+        }),
+    }))
+
+    jest.unstable_mockModule('../../lib/lint.mjs', () => ({
+        loadESLintEngine: jest.fn().mockName('mockLoadESLintEngine').mockReturnValue({
+            esLintEngine: null,
+            fatalError: false,
         }),
     }))
 
@@ -29,10 +37,15 @@ test('main() writes file when write mode is true', async () => {
 
     return main(mockConsole, '/home', 'bruno-collection', true).then(() => {
         expect(readFile).toHaveBeenCalledTimes(1)
-        expect(format).toHaveBeenCalledWith('mock file contents', null, {})
+        expect(format).toHaveBeenCalledWith('mock file contents', null, {}, null, true)
         expect(writeFile).toHaveBeenCalledWith(
             '/home/bruno-collection/Simple GET Request.bru',
             'New file contents'
+        )
+        expect(mockConsole.log).toHaveBeenNthCalledWith(1, 'Inspected 1 file:')
+        expect(mockConsole.log).toHaveBeenNthCalledWith(
+            2,
+            styleText('green', '  1 file had fixes applied 🪛')
         )
     })
 })


### PR DESCRIPTION
New feature! JavaScript blocks can be linted using ESLint. Shipped with a default ruleset but can be configured to user preference via the `esLintRules` option in the config. 