### PR TITLE
Adding option to use Prettier to format JSON blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A CLI tool to [prettify and format Bruno `.bru` files](https://www.npmjs.com/pac
 Removes junk and makes code shorter and more transferable between systems.
 Imposes a standard format on all blocks of JSON and JavaScript code across multiple [Bruno](https://www.usebruno.com/) `.bru` files in your project.
 
-`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser)
+`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally with [Prettier](https://prettier.io/) using the `jsonc` parser when the `prettifyJson` option is enabled.
 
 `script:pre-request`, `script:post-response` and `tests` blocks are formatted using [Prettier](https://prettier.io/) with [Babel](https://babeljs.io/docs/babel-parser) parser.
 
@@ -28,6 +28,7 @@ Imposes a standard format on all blocks of JSON and JavaScript code across multi
 - [Config file](#config-file)
   - [Agnostic File Paths](#agnostic-file-paths)
   - [Shorten Getters](#shorten-getters)
+  - [Prettify JSON](#prettify-json)
   - [Prettier](#prettier)
 - [Automatically checking PRs](#automatically-checking-prs)
 <!-- TOC -->
@@ -120,6 +121,16 @@ Some values target groups of blocks:
 - "script" will do both `script:pre-request` and `script:post-response`
 - "body" will target all 3 body blocks `body:json`, `body:graphql` and `body:graphql:vars`
 
+### Use Prettier for JSON formatting
+
+By default, `body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser). To use Prettier instead, add the `--prettify-json` flag:
+
+```
+npx prettify-bru --prettify-json --write
+```
+
+This will format JSON blocks using Prettier's `jsonc` parser with trailing commas disabled, producing valid JSON with comment support (which Bruno strips out). Note that this will not be in sync with the "Prettify" button in Bruno's UI, but the output will be valid JSON without trailing commas.
+
 ### Complex example
 
 Fix the formatting of just the `body:json` block in 1 specific file:
@@ -165,6 +176,24 @@ The above will become...
 expect(res.status).to.eql(200)
 expect(res.body.name).to.eql("Dave")
 ```
+
+### Prettify JSON
+
+Property: `prettifyJson` {boolean} (Default: `false`)
+
+Use Prettier (instead of jsonc-parser) to format `body:json` and `body:graphql:vars` blocks. When enabled, these blocks are formatted using Prettier's `jsonc` parser with trailing commas disabled.
+
+**Note:** This will not be in sync with the "Prettify" button in Bruno's UI, but the output will be valid JSON (no trailing commas, etc.) with comment support that Bruno trims out.
+
+To enable this in your config file:
+
+```json
+{
+    "prettifyJson": true
+}
+```
+
+Alternatively, you can use the `--prettify-json` CLI flag to enable this on a per-run basis.
 
 ### Prettier
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A CLI tool to [prettify and format Bruno `.bru` files](https://www.npmjs.com/pac
 Removes junk and makes code shorter and more transferable between systems.
 Imposes a standard format on all blocks of JSON and JavaScript code across multiple [Bruno](https://www.usebruno.com/) `.bru` files in your project.
 
-`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally with [Prettier](https://prettier.io/) using the `jsonc` parser when the `prettifyJson` option is enabled.
+`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally with [Prettier](https://prettier.io/) using the `jsonc` parser when the `jsonFormatter` option is set to "prettier".
 
 `script:pre-request`, `script:post-response` and `tests` blocks are formatted using [Prettier](https://prettier.io/) with [Babel](https://babeljs.io/docs/babel-parser) parser.
 
@@ -123,10 +123,10 @@ Some values target groups of blocks:
 
 ### Use Prettier for JSON formatting
 
-By default, `body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser). To use Prettier instead, add the `--prettify-json` flag:
+By default, `body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser). To use Prettier instead, add the `--json-formatter=prettier` flag:
 
 ```
-npx prettify-bru --prettify-json --write
+npx prettify-bru --json-formatter=prettier --write
 ```
 
 This will format JSON blocks using Prettier's `jsonc` parser with trailing commas disabled, producing valid JSON with comment support (which Bruno strips out). Note that this will not be in sync with the "Prettify" button in Bruno's UI, but the output will be valid JSON without trailing commas.
@@ -177,23 +177,25 @@ expect(res.status).to.eql(200)
 expect(res.body.name).to.eql("Dave")
 ```
 
-### Prettify JSON
+### JSON Formatter
 
-Property: `prettifyJson` {boolean} (Default: `false`)
+Property: `jsonFormatter` {string} (Default: `jsonc`)
 
-Use Prettier (instead of jsonc-parser) to format `body:json` and `body:graphql:vars` blocks. When enabled, these blocks are formatted using Prettier's `jsonc` parser with trailing commas disabled.
+Sets which formatter to use for JSON blocks (`body:json` and `body:graphql:vars`).
 
-**Note:** This will not be in sync with the "Prettify" button in Bruno's UI, but the output will be valid JSON (no trailing commas, etc.) with comment support that Bruno trims out.
+By default it matches the behaviour of the "Prettify" button in Bruno's UI by using the `format()` function from the `jsonc-parser` library. This does not auto-fix trailing commas.
 
-To enable this in your config file:
+Set this option to "prettier" to use Prettier for JSON blocks. This option will be a deviation from Bruno's UI because it will auto-fix trailing commas (Note: Prettier will still use a `jsonc` parser to support comments in JSON).
+
+To change this in your config file:
 
 ```json
 {
-    "prettifyJson": true
+    "jsonFormatter": "prettier"
 }
 ```
 
-Alternatively, you can use the `--prettify-json` CLI flag to enable this on a per-run basis.
+Alternatively, you can use the `--json-formatter=prettier` CLI flag to set this on a per-run basis.
 
 ### Prettier
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Imposes a standard format on all blocks of JSON and JavaScript code across multi
 - [Config file](#config-file)
   - [Agnostic File Paths](#agnostic-file-paths)
   - [Shorten Getters](#shorten-getters)
-  - [Prettify JSON](#prettify-json)
+  - [Use Prettier for JSON formatting](#use-prettier-for-json-formatting)
   - [Prettier](#prettier)
 - [Automatically checking PRs](#automatically-checking-prs)
 <!-- TOC -->
@@ -123,13 +123,15 @@ Some values target groups of blocks:
 
 ### Use Prettier for JSON formatting
 
-By default, `body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser). To use Prettier instead, add the `--json-formatter=prettier` flag:
+By default, `body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser), this matches the behaviour of the "Prettify" button in the Bruno application.
+
+However you may wish to use the `--json-formatter=prettier` flag to switch prettify-bru to use Prettier instead:
 
 ```
 npx prettify-bru --json-formatter=prettier --write
 ```
 
-This will format JSON blocks using Prettier's `jsonc` parser with trailing commas disabled, producing valid JSON with comment support (which Bruno strips out). Note that this will not be in sync with the "Prettify" button in Bruno's UI, but the output will be valid JSON without trailing commas.
+This will format JSON blocks using Prettier's `jsonc` parser with trailing commas disabled, meaning it will automatically fix trailing commas producing valid JSON with comments still supported. Note that this behaviour diverges from the "Prettify" button in Bruno's UI which does not strip trailing commas.
 
 ### Complex example
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A CLI tool to [prettify and format Bruno `.bru` files](https://www.npmjs.com/pac
 Removes junk and makes code shorter and more transferable between systems.
 Imposes a standard format on all blocks of JSON and JavaScript code across multiple [Bruno](https://www.usebruno.com/) `.bru` files in your project.
 
-`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally with [Prettier](https://prettier.io/) using the `jsonc` parser when the `jsonFormatter` option is set to "prettier".
+`body:json` and `body:graphql:vars` blocks are formatted using [jsonc-parser](https://www.npmjs.com/package/jsonc-parser) by default, or optionally using [Prettier](https://prettier.io/) (with the `jsonc` parser) when the `jsonFormatter` option is set to "prettier".
 
 `script:pre-request`, `script:post-response` and `tests` blocks are formatted using [Prettier](https://prettier.io/) with [Babel](https://babeljs.io/docs/babel-parser) parser.
 
@@ -181,7 +181,7 @@ expect(res.body.name).to.eql("Dave")
 
 ### JSON Formatter
 
-Property: `jsonFormatter` {string} (Default: `jsonc`)
+Property: `jsonFormatter` {string} (Default: `jsonc-parser`)
 
 Sets which formatter to use for JSON blocks (`body:json` and `body:graphql:vars`).
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Imposes a standard format on all blocks of JSON and JavaScript code across multi
   - [Limit to one directory](#limit-to-one-directory)
   - [Limit to one file](#limit-to-one-file)
   - [Limit to only a subset of blocks](#limit-to-only-a-subset-of-blocks)
+  - [Use Prettier for JSON formatting](#use-prettier-for-json-formatting)
   - [Complex example](#complex-example)
 - [Config file](#config-file)
   - [Agnostic File Paths](#agnostic-file-paths)
   - [Shorten Getters](#shorten-getters)
-  - [Use Prettier for JSON formatting](#use-prettier-for-json-formatting)
+  - [JSON Formatter](#json-formatter)
   - [Prettier](#prettier)
 - [Automatically checking PRs](#automatically-checking-prs)
 <!-- TOC -->

--- a/cli.js
+++ b/cli.js
@@ -31,24 +31,36 @@ const argv = yargs(hideBin(process.argv))
             type: 'boolean',
             default: false,
         },
+        'prettify-json': {
+            describe:
+                'Use Prettier (instead of jsonc-parser) for body:json and body:graphql:vars blocks',
+            type: 'boolean',
+            default: false,
+        },
     })
-    .boolean(['w', 'h'])
+    .boolean(['w', 'h', 'prettify-json'])
     .alias('h', 'help')
     .parse()
 
 if (argv.h) {
     yargs.showHelp()
 } else {
-    go(argv.path, argv.w, argv.only ?? null)
+    go(argv.path, argv.w, argv.only ?? null, argv['prettify-json'])
 }
 
 /**
  * @param {string} path
  * @param {boolean} write Whether to actually modify the files or not
  * @param {?string} only Limit to only the block type with a name containing value
+ * @param {boolean} prettifyJson Whether to use Prettier for JSON blocks
  */
-function go(path, write, only) {
-    main(console, process.cwd(), path, write, only)
+function go(path, write, only, prettifyJson) {
+    const cliConfig = {}
+    if (prettifyJson) {
+        cliConfig.prettifyJson = true
+    }
+
+    main(console, process.cwd(), path, write, only, cliConfig)
         .then(changesRequired => {
             if (changesRequired) {
                 process.exitCode = 1

--- a/cli.js
+++ b/cli.js
@@ -31,33 +31,34 @@ const argv = yargs(hideBin(process.argv))
             type: 'boolean',
             default: false,
         },
-        'prettify-json': {
+        'json-formatter': {
             describe:
                 'Use Prettier (instead of jsonc-parser) for body:json and body:graphql:vars blocks',
-            type: 'boolean',
-            default: false,
+            type: 'string',
+            choices: ['jsonc', 'prettier', null],
+            default: null,
         },
     })
-    .boolean(['w', 'h', 'prettify-json'])
+    .boolean(['w', 'h'])
     .alias('h', 'help')
     .parse()
 
 if (argv.h) {
     yargs.showHelp()
 } else {
-    go(argv.path, argv.w, argv.only ?? null, argv['prettify-json'])
+    go(argv.path, argv.w, argv.only ?? null, argv['json-formatter'])
 }
 
 /**
  * @param {string} path
  * @param {boolean} write Whether to actually modify the files or not
  * @param {?string} only Limit to only the block type with a name containing value
- * @param {boolean} prettifyJson Whether to use Prettier for JSON blocks
+ * @param {string} jsonFormatter Whether to use Prettier for JSON blocks
  */
-function go(path, write, only, prettifyJson) {
+function go(path, write, only, jsonFormatter) {
     const cliConfig = {}
-    if (prettifyJson) {
-        cliConfig.prettifyJson = true
+    if (jsonFormatter !== null) {
+        cliConfig.jsonFormatter = jsonFormatter
     }
 
     main(console, process.cwd(), path, write, only, cliConfig)

--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,7 @@ const argv = yargs(hideBin(process.argv))
             describe:
                 'Use Prettier (instead of jsonc-parser) for body:json and body:graphql:vars blocks',
             type: 'string',
-            choices: ['jsonc', 'prettier', null],
+            choices: ['jsonc-parser', 'prettier', null],
             default: null,
         },
     })

--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ if (argv.h) {
  * @param {string} path
  * @param {boolean} write Whether to actually modify the files or not
  * @param {?string} only Limit to only the block type with a name containing value
- * @param {string} jsonFormatter Whether to use Prettier for JSON blocks
+ * @param {?string} jsonFormatter Whether to use Prettier for JSON blocks
  */
 function go(path, write, only, jsonFormatter) {
     const cliConfig = {}

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -7,6 +7,7 @@ const configFilename = '.prettifybrurc'
  * @typedef {Object} PrettifyBruConfig
  * @property {boolean} agnosticFilePaths
  * @property {boolean} shortenGetters
+ * @property {boolean} prettifyJson
  * @property {Object} prettier Prettier options
  */
 
@@ -14,6 +15,7 @@ const configFilename = '.prettifybrurc'
 export const defaultConfig = {
     agnosticFilePaths: true,
     shortenGetters: true,
+    prettifyJson: false,
     prettier: {},
 }
 
@@ -64,6 +66,7 @@ export function parseFile(console, fileContents) {
     const supportedProperties = {
         agnosticFilePaths: 'a boolean',
         shortenGetters: 'a boolean',
+        prettifyJson: 'a boolean',
         prettier: 'an object',
     }
     Object.keys(fileConfig).forEach(key => {

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -7,7 +7,7 @@ const configFilename = '.prettifybrurc'
  * @typedef {Object} PrettifyBruConfig
  * @property {boolean} agnosticFilePaths
  * @property {boolean} shortenGetters
- * @property {'jsonc'|'prettier'} jsonFormatter
+ * @property {'jsonc-parser'|'prettier'} jsonFormatter
  * @property {Object} prettier Prettier options
  */
 
@@ -15,7 +15,7 @@ const configFilename = '.prettifybrurc'
 export const defaultConfig = {
     agnosticFilePaths: true,
     shortenGetters: true,
-    jsonFormatter: 'jsonc',
+    jsonFormatter: 'jsonc-parser',
     prettier: {},
 }
 
@@ -66,7 +66,7 @@ export function parseFile(console, fileContents) {
     const supportedProperties = {
         agnosticFilePaths: 'a boolean',
         shortenGetters: 'a boolean',
-        jsonFormatter: 'jsonc or prettier',
+        jsonFormatter: 'jsonc-parser or prettier',
         prettier: 'an object',
     }
     Object.keys(fileConfig).forEach(key => {
@@ -99,5 +99,5 @@ const validators = {
     'a boolean': value => {
         return typeof value === 'boolean'
     },
-    'jsonc or prettier': value => value === 'jsonc' || value === 'prettier',
+    'jsonc-parser or prettier': value => value === 'jsonc-parser' || value === 'prettier',
 }

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -7,7 +7,7 @@ const configFilename = '.prettifybrurc'
  * @typedef {Object} PrettifyBruConfig
  * @property {boolean} agnosticFilePaths
  * @property {boolean} shortenGetters
- * @property {{'jsonc'|'prettier'}} jsonFormatter
+ * @property {'jsonc'|'prettier'} jsonFormatter
  * @property {Object} prettier Prettier options
  */
 

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -7,7 +7,7 @@ const configFilename = '.prettifybrurc'
  * @typedef {Object} PrettifyBruConfig
  * @property {boolean} agnosticFilePaths
  * @property {boolean} shortenGetters
- * @property {boolean} prettifyJson
+ * @property {{'jsonc'|'prettier'}} jsonFormatter
  * @property {Object} prettier Prettier options
  */
 
@@ -15,7 +15,7 @@ const configFilename = '.prettifybrurc'
 export const defaultConfig = {
     agnosticFilePaths: true,
     shortenGetters: true,
-    prettifyJson: false,
+    jsonFormatter: 'jsonc',
     prettier: {},
 }
 
@@ -66,7 +66,7 @@ export function parseFile(console, fileContents) {
     const supportedProperties = {
         agnosticFilePaths: 'a boolean',
         shortenGetters: 'a boolean',
-        prettifyJson: 'a boolean',
+        jsonFormatter: 'jsonc or prettier',
         prettier: 'an object',
     }
     Object.keys(fileConfig).forEach(key => {
@@ -99,4 +99,5 @@ const validators = {
     'a boolean': value => {
         return typeof value === 'boolean'
     },
+    'jsonc or prettier': value => value === 'jsonc' || value === 'prettier',
 }

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -132,7 +132,7 @@ async function formatBlock(fileContents, blockName, config) {
 
     let reformatted
 
-    if (blockName === 'body:json' || blockName === 'body:graphql:vars') {
+    if ((blockName === 'body:json' || blockName === 'body:graphql:vars') && !config.prettifyJson) {
         unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
         const edits = jsoncFormat(unindented, undefined, {tabSize: 2, insertSpaces: true})
         reformatted = applyEdits(unindented, edits)
@@ -144,9 +144,18 @@ async function formatBlock(fileContents, blockName, config) {
                 opts.parser = 'graphql'
                 opts.bracketSpacing = true
                 unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
+            } else if (blockName === 'body:json' || blockName === 'body:graphql:vars') {
+                // Use Prettier with jsonc parser for JSON blocks when prettifyJson is enabled
+                opts.parser = 'jsonc'
+                opts.trailingComma = 'none'
+                unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
             }
             reformatted = await prettier.format(unindented, opts)
-            if (blockName === 'body:graphql') {
+            if (
+                blockName === 'body:graphql' ||
+                blockName === 'body:json' ||
+                blockName === 'body:graphql:vars'
+            ) {
                 reformatted = unwrapDelimitedPlaceholders(reformatted)
             }
         } catch (e) {

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -132,7 +132,10 @@ async function formatBlock(fileContents, blockName, config) {
 
     let reformatted
 
-    if ((blockName === 'body:json' || blockName === 'body:graphql:vars') && !config.prettifyJson) {
+    if (
+        (blockName === 'body:json' || blockName === 'body:graphql:vars') &&
+        config.jsonFormatter === 'jsonc'
+    ) {
         unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
         const edits = jsoncFormat(unindented, undefined, {tabSize: 2, insertSpaces: true})
         reformatted = applyEdits(unindented, edits)
@@ -145,7 +148,7 @@ async function formatBlock(fileContents, blockName, config) {
                 opts.bracketSpacing = true
                 unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
             } else if (blockName === 'body:json' || blockName === 'body:graphql:vars') {
-                // Use Prettier with jsonc parser for JSON blocks when prettifyJson is enabled
+                // Use Prettier with jsonc parser for JSON blocks when jsonFormatter is set to "prettier"
                 opts.parser = 'jsonc'
                 opts.trailingComma = 'none'
                 unindented = wrapNonStringPlaceholdersInDelimiters(unindented)

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -134,7 +134,7 @@ async function formatBlock(fileContents, blockName, config) {
 
     if (
         (blockName === 'body:json' || blockName === 'body:graphql:vars') &&
-        config.jsonFormatter === 'jsonc'
+        config.jsonFormatter === 'jsonc-parser'
     ) {
         unindented = wrapNonStringPlaceholdersInDelimiters(unindented)
         const edits = jsoncFormat(unindented, undefined, {tabSize: 2, insertSpaces: true})

--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -12,9 +12,10 @@ import {styleText} from 'node:util'
  * @param {string} path
  * @param {boolean} write
  * @param {?string} only Limit to only the block type with a name containing value
+ * @param {Object} cliConfig Configuration overrides from CLI flags
  * @returns {Promise<boolean>} True means some files contained errors or needed reformatting
  */
-export async function main(console, cwd, path, write, only = null) {
+export async function main(console, cwd, path, write, only = null, cliConfig = {}) {
     validateOnlyParam(only)
 
     if (path === '') {
@@ -31,7 +32,7 @@ export async function main(console, cwd, path, write, only = null) {
         return false
     }
 
-    const config = loadConfigFile(console)
+    const config = {...loadConfigFile(console), ...cliConfig}
 
     let changeableFiles = []
     let erroredFiles = []

--- a/test/config/config_parse_file.test.js
+++ b/test/config/config_parse_file.test.js
@@ -52,6 +52,17 @@ describe('parseFile() function in config module', () => {
         expect(config).toEqual({})
     })
 
+    it('warns if `prettifyJson` is not a boolean', () => {
+        const mockConsole = {log: jest.fn(), warn: jest.fn()}
+        // This config incorrectly sets `prettifyJson` property as a string
+        const config = parseFile(mockConsole, '{"prettifyJson": "yes"}')
+
+        expect(mockConsole.warn).toHaveBeenCalledWith(
+            `⚠️  ${styleText('yellow', '"prettifyJson" is not correct type, it should be a boolean')}`
+        )
+        expect(config).toEqual({})
+    })
+
     it('warns if `prettier` is not an object', () => {
         const mockConsole = {log: jest.fn(), warn: jest.fn()}
         // This config incorrectly provides an array for the prettier property
@@ -85,6 +96,13 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"shortenGetters": false}')
 
         expect(config).toEqual({shortenGetters: false})
+    })
+
+    it('transfers `prettifyJson` property', () => {
+        const mockConsole = {log: jest.fn()}
+        const config = parseFile(mockConsole, '{"prettifyJson": true}')
+
+        expect(config).toEqual({prettifyJson: true})
     })
 
     it('transfers `prettier` property', () => {

--- a/test/config/config_parse_file.test.js
+++ b/test/config/config_parse_file.test.js
@@ -58,7 +58,7 @@ describe('parseFile() function in config module', () => {
         const config = parseFile(mockConsole, '{"jsonFormatter": true}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            `⚠️  ${styleText('yellow', '"jsonFormatter" is not correct type, it should be jsonc or prettier')}`
+            `⚠️  ${styleText('yellow', '"jsonFormatter" is not correct type, it should be jsonc-parser or prettier')}`
         )
         expect(config).toEqual({})
     })

--- a/test/config/config_parse_file.test.js
+++ b/test/config/config_parse_file.test.js
@@ -52,13 +52,13 @@ describe('parseFile() function in config module', () => {
         expect(config).toEqual({})
     })
 
-    it('warns if `prettifyJson` is not a boolean', () => {
+    it('warns if `jsonFormatter` is not a string', () => {
         const mockConsole = {log: jest.fn(), warn: jest.fn()}
-        // This config incorrectly sets `prettifyJson` property as a string
-        const config = parseFile(mockConsole, '{"prettifyJson": "yes"}')
+        // This config incorrectly sets `jsonFormatter` property as a boolean
+        const config = parseFile(mockConsole, '{"jsonFormatter": true}')
 
         expect(mockConsole.warn).toHaveBeenCalledWith(
-            `⚠️  ${styleText('yellow', '"prettifyJson" is not correct type, it should be a boolean')}`
+            `⚠️  ${styleText('yellow', '"jsonFormatter" is not correct type, it should be jsonc or prettier')}`
         )
         expect(config).toEqual({})
     })
@@ -98,11 +98,11 @@ describe('parseFile() function in config module', () => {
         expect(config).toEqual({shortenGetters: false})
     })
 
-    it('transfers `prettifyJson` property', () => {
+    it('transfers `jsonFormatter` property', () => {
         const mockConsole = {log: jest.fn()}
-        const config = parseFile(mockConsole, '{"prettifyJson": true}')
+        const config = parseFile(mockConsole, '{"jsonFormatter": "prettier"}')
 
-        expect(config).toEqual({prettifyJson: true})
+        expect(config).toEqual({jsonFormatter: 'prettier'})
     })
 
     it('transfers `prettier` property', () => {

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -989,4 +989,77 @@ describe('The format() function', () => {
             expect(result.changeable).toBe(false)
         })
     })
+
+    it.each(['body:json', 'body:graphql:vars'])(
+        'uses Prettier for %s when prettifyJson is enabled with no trailing commas',
+        async blockName => {
+            const originalFileContents = [
+                '',
+                blockName + ' {',
+                '  {',
+                '      "this": [ {{somePlaceholder}}, "b", "c",],',
+                '  "number": 7,',
+                '  }',
+                '}',
+                '',
+            ].join('\n')
+
+            const expected = [
+                '',
+                blockName + ' {',
+                '  {',
+                '    "this": [{{somePlaceholder}}, "b", "c"],',
+                '    "number": 7',
+                '  }',
+                '}',
+                '',
+            ].join('\n')
+
+            const config = {prettifyJson: true}
+
+            expect.assertions(3)
+            return format(originalFileContents, null, config).then(result => {
+                console.log(result.newContents)
+                expect(result.newContents).toBe(expected)
+                expect(result.errorMessages).toStrictEqual([])
+                expect(result.changeable).toBe(true)
+            })
+        }
+    )
+
+    it('does not add trailing commas when prettifyJson is enabled', async () => {
+        const originalFileContents = [
+            '',
+            'body:json {',
+            '  {',
+            '    "key1": "value1",',
+            '    "key2": "value2"',
+            '  }',
+            '}',
+            '',
+        ].join('\n')
+
+        const config = {prettifyJson: true}
+
+        expect.assertions(2)
+        return format(originalFileContents, null, config).then(result => {
+            expect(result.newContents).toBe(originalFileContents)
+            expect(result.changeable).toBe(false)
+        })
+    })
+
+    it('returns error when Prettier cannot format body:json with prettifyJson enabled', async () => {
+        const invalidJson = '{"key": invalid}'
+        const originalFileContents = ['', 'body:json {', `  ${invalidJson}`, '}', ''].join('\n')
+
+        const config = {prettifyJson: true}
+
+        expect.assertions(2)
+        return format(originalFileContents, null, config).then(result => {
+            expect(result.errorMessages).toHaveLength(1)
+            expect(result.errorMessages[0]).toContain(
+                'Prettier could not format body:json because...'
+            )
+        })
+    })
 })

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1019,7 +1019,6 @@ describe('The format() function', () => {
 
             expect.assertions(3)
             return format(originalFileContents, null, config).then(result => {
-                console.log(result.newContents)
                 expect(result.newContents).toBe(withoutTrailingCommas)
                 expect(result.errorMessages).toStrictEqual([])
                 expect(result.changeable).toBe(true)

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -991,7 +991,7 @@ describe('The format() function', () => {
     })
 
     it.each(['body:json', 'body:graphql:vars'])(
-        'uses Prettier for %s when prettifyJson is enabled with no trailing commas',
+        'uses Prettier for %s when jsonFormatter is set to "prettier"',
         async blockName => {
             const originalFileContents = [
                 '',
@@ -1004,7 +1004,7 @@ describe('The format() function', () => {
                 '',
             ].join('\n')
 
-            const expected = [
+            const withoutTrailingCommas = [
                 '',
                 blockName + ' {',
                 '  {',
@@ -1015,44 +1015,23 @@ describe('The format() function', () => {
                 '',
             ].join('\n')
 
-            const config = {prettifyJson: true}
+            const config = {jsonFormatter: 'prettier'}
 
             expect.assertions(3)
             return format(originalFileContents, null, config).then(result => {
                 console.log(result.newContents)
-                expect(result.newContents).toBe(expected)
+                expect(result.newContents).toBe(withoutTrailingCommas)
                 expect(result.errorMessages).toStrictEqual([])
                 expect(result.changeable).toBe(true)
             })
         }
     )
 
-    it('does not add trailing commas when prettifyJson is enabled', async () => {
-        const originalFileContents = [
-            '',
-            'body:json {',
-            '  {',
-            '    "key1": "value1",',
-            '    "key2": "value2"',
-            '  }',
-            '}',
-            '',
-        ].join('\n')
-
-        const config = {prettifyJson: true}
-
-        expect.assertions(2)
-        return format(originalFileContents, null, config).then(result => {
-            expect(result.newContents).toBe(originalFileContents)
-            expect(result.changeable).toBe(false)
-        })
-    })
-
-    it('returns error when Prettier cannot format body:json with prettifyJson enabled', async () => {
+    it('returns error when Prettier cannot format body:json with jsonFormatter set to "prettier"', async () => {
         const invalidJson = '{"key": invalid}'
         const originalFileContents = ['', 'body:json {', `  ${invalidJson}`, '}', ''].join('\n')
 
-        const config = {prettifyJson: true}
+        const config = {jsonFormatter: 'preetier'}
 
         expect.assertions(2)
         return format(originalFileContents, null, config).then(result => {

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1030,7 +1030,7 @@ describe('The format() function', () => {
         const invalidJson = '{"key": invalid}'
         const originalFileContents = ['', 'body:json {', `  ${invalidJson}`, '}', ''].join('\n')
 
-        const config = {jsonFormatter: 'preetier'}
+        const config = {jsonFormatter: 'prettier'}
 
         expect.assertions(2)
         return format(originalFileContents, null, config).then(result => {


### PR DESCRIPTION
Copy of #30 but with 1 commit added to rename the `prettifyJson` option to `jsonFormatter`